### PR TITLE
Relax pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "groundlight"
-version = "0.5.3"
+version = "0.5.4"
 license = "MIT"
 readme = "UserGuide.md"
 homepage = "https://groundlight.ai"


### PR DESCRIPTION
Vai's request:

```
Any way that the pypi package can work with pydantic < 1.9.1? Ideally meets these:

pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4` (these are set by `fastai` package)
```