### PR TITLE
Adding py3.11 into test matrix

### DIFF
--- a/.github/workflows/test-integ.yaml
+++ b/.github/workflows/test-integ.yaml
@@ -5,7 +5,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-20.04
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: [
             #"3.6",   # Default on Ubuntu18.04 but openapi-generator fails
@@ -13,7 +13,7 @@ jobs:
             "3.8", 
             "3.9", 
             "3.10", 
-            #"3.11",  # Not passing tests. No useful error messages.
+            "3.11",
         ]
     env:
       # This is associated with the "sdk-integ-test" user, credentials on 1password


### PR DESCRIPTION
Never figured out why py3.11 wasn't working in the test matrix before.  But whatever was wrong (it was _just_ after official release) it's working now.