### PR TITLE
Fixing bad breaking bug in endpoint url sanitization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ generate: install  ## Generate the SDK from our public openapi spec
 
 
 test-local: install  ## Run integration tests against an API server running at http://localhost:8000/device-api (needs GROUNDLIGHT_API_TOKEN)
-	GROUNDLIGHT_TEST_API_ENDPOINT="http://localhost:8000/device-api" poetry run pytest --cov=src test --log-cli-level INFO
+	GROUNDLIGHT_API_ENDPOINT="http://localhost:8000/" poetry run pytest --cov=src test --log-cli-level INFO
 
 
 test-integ: install  ## Run integration tests against the integ API server (needs GROUNDLIGHT_API_TOKEN)
-	GROUNDLIGHT_TEST_API_ENDPOINT="https://api.integ.groundlight.ai/device-api" poetry run pytest --cov=src test --log-cli-level INFO
+	GROUNDLIGHT_API_ENDPOINT="https://api.integ.groundlight.ai/" poetry run pytest --cov=src test --log-cli-level INFO

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ generate: install  ## Generate the SDK from our public openapi spec
 
 
 test-local: install  ## Run integration tests against an API server running at http://localhost:8000/device-api (needs GROUNDLIGHT_API_TOKEN)
-	GROUNDLIGHT_API_ENDPOINT="http://localhost:8000/" poetry run pytest --cov=src test --log-cli-level INFO
+	GROUNDLIGHT_ENDPOINT="http://localhost:8000/" poetry run pytest --cov=src test --log-cli-level INFO
 
 
 test-integ: install  ## Run integration tests against the integ API server (needs GROUNDLIGHT_API_TOKEN)
-	GROUNDLIGHT_API_ENDPOINT="https://api.integ.groundlight.ai/" poetry run pytest --cov=src test --log-cli-level INFO
+	GROUNDLIGHT_ENDPOINT="https://api.integ.groundlight.ai/" poetry run pytest --cov=src test --log-cli-level INFO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "groundlight"
-version = "0.7.0"
+version = "0.7.1"
 license = "MIT"
 readme = "README.md"
 homepage = "https://www.groundlight.ai"

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -43,7 +43,7 @@ class Groundlight:
     POLLING_EXPONENTIAL_BACKOFF = 1.3  # This still has the nice backoff property that the max number of requests
     # is O(log(time)), but with 1.3 the guarantee is that the call will return no more than 30% late
 
-    def __init__(self, endpoint: str = DEFAULT_ENDPOINT, api_token: str = None):
+    def __init__(self, endpoint: Optional[str] = None, api_token: str = None):
         """
         :param endpoint: optionally specify a different endpoint
         :param api_token: use this API token for your API calls. If unset, fallback to the

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -51,7 +51,7 @@ class Groundlight:
         """
         # Specify the endpoint
         self.endpoint = sanitize_endpoint_url(endpoint)
-        configuration = Configuration(host=endpoint)
+        configuration = Configuration(host=self.endpoint)
 
         if api_token is None:
             try:

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -201,6 +201,7 @@ class Groundlight:
             image_query_id = image_query.id
         else:
             image_query_id = str(image_query)
+            # Some old imagequery id's started with "chk_"
             if not (image_query_id.startswith("chk_") or image_query_id.startswith("iq_")):
                 raise ValueError(f"Invalid image query id {image_query_id}")
         api_label = convert_display_label_to_internal(image_query_id, label)

--- a/src/groundlight/config.py
+++ b/src/groundlight/config.py
@@ -1,9 +1,7 @@
-import os
-
 API_TOKEN_WEB_URL = "https://app.groundlight.ai/reef/my-account/api-tokens"
 API_TOKEN_VARIABLE_NAME = "GROUNDLIGHT_API_TOKEN"
 
-DEFAULT_ENDPOINT = os.environ.get("GROUNDLIGHT_ENDPOINT", "https://api.groundlight.ai/")
+DEFAULT_ENDPOINT = "https://api.groundlight.ai/"
 
 __all__ = [
     "API_TOKEN_WEB_URL",

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -3,6 +3,7 @@ import time
 import uuid
 from typing import Dict
 from urllib.parse import urlsplit, urlunsplit
+from groundlight.config import DEFAULT_ENDPOINT
 
 import model
 import requests
@@ -17,6 +18,8 @@ def sanitize_endpoint_url(endpoint: str) -> str:
     This allows people to leave that off entirely, or add a trailing slash.
     Also some future-proofing by allowing "v1" or "v2" or "v3" paths.
     """
+    if not endpoint:
+        endpoint = os.environ.get("GROUNDLIGHT_ENDPOINT", "https://api.groundlight.ai/")
     parts = urlsplit(endpoint)
     if (parts.scheme not in ("http", "https")) or (not parts.netloc):
         raise ValueError(

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -21,7 +21,10 @@ def sanitize_endpoint_url(endpoint: str) -> str:
     Also some future-proofing by allowing "v1" or "v2" or "v3" paths.
     """
     if not endpoint:
-        endpoint = os.environ.get("GROUNDLIGHT_ENDPOINT", "https://api.groundlight.ai/")
+        endpoint = os.environ.get("GROUNDLIGHT_ENDPOINT", "")
+        if not endpoint:
+            # Because sometimes people set an environment variable to a blank string by mistake
+            endpoint = "https://api.groundlight.ai/"
     parts = urlsplit(endpoint)
     if (parts.scheme not in ("http", "https")) or (not parts.netloc):
         raise ValueError(

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -1,8 +1,10 @@
 import logging
+import os
 import time
-import uuid
 from typing import Dict
 from urllib.parse import urlsplit, urlunsplit
+import uuid
+
 from groundlight.config import DEFAULT_ENDPOINT
 
 import model

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -25,7 +25,8 @@ def detector(gl: Groundlight) -> Detector:
 
 @pytest.fixture
 def image_query(gl: Groundlight, detector: Detector) -> ImageQuery:
-    return gl.submit_image_query(detector=detector.id, image="test/assets/dog.jpeg")
+    iq = gl.submit_image_query(detector=detector.id, image="test/assets/dog.jpeg")
+    return iq
 
 
 def test_create_detector(gl: Groundlight):
@@ -120,7 +121,8 @@ def test_add_label_to_object(gl: Groundlight, image_query: ImageQuery):
 
 def test_add_label_by_id(gl: Groundlight, image_query: ImageQuery):
     iqid = image_query.id
-    assert iqid.startswith("iq_")
+    # TODO: Fully deprecate chk_ prefix
+    assert iqid.startswith("chk_") or iqid.startswith("iq_")
     gl.add_label(iqid, "No")
 
 

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -12,8 +12,7 @@ from groundlight.optional_imports import *
 @pytest.fixture
 def gl() -> Groundlight:
     """Creates a Groundlight client object for testing."""
-    endpoint = os.environ.get("GROUNDLIGHT_TEST_API_ENDPOINT", "http://localhost:8000/device-api")
-    return Groundlight(endpoint=endpoint)
+    return Groundlight()
 
 
 @pytest.fixture
@@ -121,7 +120,7 @@ def test_add_label_to_object(gl: Groundlight, image_query: ImageQuery):
 
 def test_add_label_by_id(gl: Groundlight, image_query: ImageQuery):
     iqid = image_query.id
-    assert iqid.startswith("chk_")  # someday we'll probably change this to iq_
+    assert iqid.startswith("iq_")
     gl.add_label(iqid, "No")
 
 


### PR DESCRIPTION
A funny-to-me set of coincidences let this bug through all our tests.  The endpoint sanitizer was well tested in unit tests, but the integration wasn't quite right, and the integration tests skipped the sanitizer.  That's fixed now.  As is the bug.