### PR TITLE
Fix tests (improve `get_detector_by_name()`)

### DIFF
--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -4,23 +4,26 @@ import time
 from io import BufferedReader, BytesIO
 from typing import Optional, Union
 
-from groundlight.optional_imports import Image
 from model import Detector, ImageQuery, PaginatedDetectorList, PaginatedImageQueryList
-from openapi_client import ApiClient, Configuration
+from openapi_client import Configuration
 from openapi_client.api.detectors_api import DetectorsApi
 from openapi_client.api.image_queries_api import ImageQueriesApi
 from openapi_client.model.detector_creation_input import DetectorCreationInput
 
-from groundlight.binary_labels import convert_display_label_to_internal, convert_internal_label_to_display
-from groundlight.config import API_TOKEN_VARIABLE_NAME, API_TOKEN_WEB_URL, DEFAULT_ENDPOINT
-from groundlight.images import buffer_from_jpeg_file, jpeg_from_numpy, parse_supported_image_types
+from groundlight.binary_labels import convert_display_label_to_internal
+from groundlight.config import API_TOKEN_VARIABLE_NAME, API_TOKEN_WEB_URL
+from groundlight.images import parse_supported_image_types
 from groundlight.internalapi import GroundlightApiClient, sanitize_endpoint_url
-from groundlight.optional_imports import np
+from groundlight.optional_imports import Image, np
 
 logger = logging.getLogger("groundlight.sdk")
 
 
 class ApiTokenError(Exception):
+    pass
+
+
+class NotFoundException(Exception):
     pass
 
 
@@ -81,15 +84,14 @@ class Groundlight:
         return Detector.parse_obj(obj.to_dict())
 
     def get_detector_by_name(self, name: str) -> Optional[Detector]:
-        # TODO: Do this on server.
-        detector_list = self.list_detectors(page_size=250)
-        for d in detector_list.results:
-            if d.name == name:
-                return d
-        if detector_list.next:
-            # TODO: paginate
-            raise RuntimeError("You have too many detectors to use get_detector_by_name")
-        return None
+        response = self.api_client._get_detector_by_name(name)
+        if response["count"] == 0:
+            raise NotFoundException(f"Detector with name={name} not found.")
+        elif response["count"] > 1:
+            raise RuntimeError(
+                f"We found multiple ({response['count']}) detectors with the same name. This shouldn't happen."
+            )
+        return Detector.parse_obj(response["results"][0])
 
     def list_detectors(self, page: int = 1, page_size: int = 10) -> PaginatedDetectorList:
         obj = self.detectors_api.list_detectors(page=page, page_size=page_size)

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -23,10 +23,6 @@ class ApiTokenError(Exception):
     pass
 
 
-class NotFoundException(Exception):
-    pass
-
-
 class Groundlight:
     """
     Client for accessing the Groundlight cloud service.
@@ -84,14 +80,7 @@ class Groundlight:
         return Detector.parse_obj(obj.to_dict())
 
     def get_detector_by_name(self, name: str) -> Optional[Detector]:
-        response = self.api_client._get_detector_by_name(name)
-        if response["count"] == 0:
-            raise NotFoundException(f"Detector with name={name} not found.")
-        elif response["count"] > 1:
-            raise RuntimeError(
-                f"We found multiple ({response['count']}) detectors with the same name. This shouldn't happen."
-            )
-        return Detector.parse_obj(response["results"][0])
+        return self.api_client._get_detector_by_name(name)
 
     def list_detectors(self, page: int = 1, page_size: int = 10) -> PaginatedDetectorList:
         obj = self.detectors_api.list_detectors(page=page, page_size=page_size)

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -79,7 +79,7 @@ class Groundlight:
         obj = self.detectors_api.get_detector(id=id)
         return Detector.parse_obj(obj.to_dict())
 
-    def get_detector_by_name(self, name: str) -> Optional[Detector]:
+    def get_detector_by_name(self, name: str) -> Detector:
         return self.api_client._get_detector_by_name(name)
 
     def list_detectors(self, page: int = 1, page_size: int = 10) -> PaginatedDetectorList:

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -1,15 +1,15 @@
 import logging
 import os
 import time
+import uuid
 from typing import Dict
 from urllib.parse import urlsplit, urlunsplit
-import uuid
-
-from groundlight.config import DEFAULT_ENDPOINT
 
 import model
 import requests
 from openapi_client.api_client import ApiClient
+
+from groundlight.config import DEFAULT_ENDPOINT
 
 logger = logging.getLogger("groundlight.sdk")
 
@@ -112,6 +112,26 @@ class GroundlightApiClient(ApiClient):
         if response.status_code != 200:
             raise InternalApiException(
                 f"Error adding label to image query {image_query_id} status={response.status_code} {response.text}"
+            )
+
+        return response.json()
+
+    def _get_detector_by_name(self, name: str) -> dict:
+        """Get a detector by name. For now, we use the list detectors API directly.
+
+        TODO: Properly model this in the API, and generate SDK code for it.
+        """
+        url = f"{self.configuration.host}/v1/detectors?name={name}"
+
+        headers = self._headers()
+
+        logger.info(f"Getting detector by {name=} ...")
+        response = requests.request("GET", url, headers=headers)
+        logger.debug(f"Response to _get_detector_by_name(): {response.text}")
+
+        if response.status_code != 200:
+            raise InternalApiException(
+                f"Error getting detector by {name=}: status={response.status_code}; {response.text}"
             )
 
         return response.json()

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -125,13 +125,13 @@ class GroundlightApiClient(ApiClient):
 
         headers = self._headers()
 
-        logger.info(f"Getting detector by {name=} ...")
+        logger.info(f"Getting detector by name '{name}' ...")
         response = requests.request("GET", url, headers=headers)
         logger.debug(f"Response to _get_detector_by_name(): {response.text}")
 
         if response.status_code != 200:
             raise InternalApiException(
-                f"Error getting detector by {name=}: status={response.status_code}; {response.text}"
+                f"Error getting detector by name '{name}': status={response.status_code}; {response.text}"
             )
 
         return response.json()

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -3,10 +3,10 @@ from datetime import datetime
 
 import openapi_client
 import pytest
-from model import Detector, ImageQuery, PaginatedDetectorList, PaginatedImageQueryList
-
 from groundlight import Groundlight
+from groundlight.client import NotFoundException
 from groundlight.optional_imports import *
+from model import Detector, ImageQuery, PaginatedDetectorList, PaginatedImageQueryList
 
 
 @pytest.fixture
@@ -60,6 +60,16 @@ def test_get_detector(gl: Groundlight, detector: Detector):
     _detector = gl.get_detector(id=detector.id)
     assert str(_detector)
     assert isinstance(_detector, Detector)
+
+
+def test_get_detector_by_name(gl: Groundlight, detector: Detector):
+    _detector = gl.get_detector_by_name(name=detector.name)
+    assert str(_detector)
+    assert isinstance(_detector, Detector)
+    assert _detector.id == detector.id
+
+    with pytest.raises(NotFoundException):
+        gl.get_detector_by_name(name="not a real name")
 
 
 def test_submit_image_query_blocking(gl: Groundlight, detector: Detector):

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import openapi_client
 import pytest
 from groundlight import Groundlight
-from groundlight.client import NotFoundException
+from groundlight.internalapi import NotFoundException
 from groundlight.optional_imports import *
 from model import Detector, ImageQuery, PaginatedDetectorList, PaginatedImageQueryList
 


### PR DESCRIPTION
Our tests have been failing because `get_detector_by_name()` was doing the name-filtering on the client side. This change moves the filter to the server side, so it's fast and simpler.