### PR TITLE
Bugfix for `get_or_create_detector()` unique name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
     {include = "**/*.py", from = "src"},
 ]
 readme = "README.md"
-version = "0.7.7"
+version = "0.7.8"
 
 [tool.poetry.dependencies]
 certifi = "^2021.10.8"

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -112,7 +112,7 @@ class Groundlight:
         try:
             existing_detector = self.get_detector_by_name(name)
         except NotFoundError:
-            logger.debug(f"Detector with name={name} not found. Creating a new detector.")
+            logger.debug(f"We could not find a detector with name='{name}'. So we will create a new detector ...")
             return self.create_detector(
                 name=name, query=query, confidence_threshold=confidence_threshold, config_name=config_name
             )

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -100,6 +100,19 @@ def test_list_detectors(gl: Groundlight):
     assert isinstance(detectors, PaginatedDetectorList)
 
 
+def test_get_or_create_detector(gl: Groundlight):
+    # With a unique name, we should be creating a new detector.
+    unique_name = f"Unique name {datetime.utcnow()}"
+    query = "Test query?"
+    detector = gl.get_or_create_detector(name=unique_name, query=query)
+    assert str(detector)
+    assert isinstance(detector, Detector)
+
+    # If we try to create a detector with the same name, we should get the same detector back.
+    retrieved_detector = gl.get_or_create_detector(name=unique_name, query=query)
+    assert retrieved_detector.id == detector.id
+
+
 def test_get_detector(gl: Groundlight, detector: Detector):
     _detector = gl.get_detector(id=detector.id)
     assert str(_detector)


### PR DESCRIPTION
I found a bug where `get_or_create_detector()` wasn't handling new detectors properly. We hadn't noticed before because we didn't have a test that operated on an explicitly unique detector name.

Longer term: maybe the "get-or-create" functionality should be happening server-side anyway?