### PR TITLE
(0.8.0rc1) Return YES/NO instead of PASS/FAIL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
     {include = "**/*.py", from = "src"},
 ]
 readme = "README.md"
-version = "0.7.8"
+version = "0.8.0"
 
 [tool.poetry.dependencies]
 certifi = "^2021.10.8"

--- a/src/groundlight/binary_labels.py
+++ b/src/groundlight/binary_labels.py
@@ -1,4 +1,4 @@
-"""Defines the possible values for binary class labels like Yes/No or PASS/FAIL.
+"""Defines the possible values for binary class labels like YES/NO or PASS/FAIL.
 Provides methods to convert between them.
 
 This part of the API is kinda ugly right now.  So we'll encapsulate the ugliness in one place.
@@ -11,6 +11,13 @@ from model import Detector, ImageQuery
 logger = logging.getLogger("groundlight.sdk")
 
 
+PASS_DEPRECATED = "PASS"
+FAIL_DEPRECATED = "FAIL"
+YES = "YES"
+NO = "NO"
+DEPRECATED_LABEL_NAMES = {PASS_DEPRECATED, FAIL_DEPRECATED}
+
+
 def internal_labels_for_detector(
     context: Union[ImageQuery, Detector, str],  # pylint: disable=unused-argument
 ) -> List[str]:
@@ -19,7 +26,7 @@ def internal_labels_for_detector(
     :param context: Can be an ImageQuery, a Detector, or a string-id for one of them.
     """
     # NOTE: At some point this will need to be an API call, because these will be defined per-detector
-    return ["PASS", "FAIL"]
+    return [PASS_DEPRECATED, FAIL_DEPRECATED]
 
 
 def convert_internal_label_to_display(
@@ -28,11 +35,11 @@ def convert_internal_label_to_display(
 ) -> str:
     # NOTE: Someday we will do nothing here, when the server provides properly named classes.
     upper = label.upper()
-    if upper == "PASS":
-        return "YES"
-    if upper == "FAIL":
-        return "NO"
-    if upper in ["YES", "NO"]:
+    if upper == PASS_DEPRECATED:
+        return YES
+    if upper == FAIL_DEPRECATED:
+        return NO
+    if upper in {PASS_DEPRECATED, NO}:
         return label
     logger.warning(f"Unrecognized internal label {label} - leaving alone.")
     return label
@@ -44,8 +51,8 @@ def convert_display_label_to_internal(
 ) -> str:
     # NOTE: In the future we should validate against actually supported labels for the detector
     upper = label.upper()
-    if upper in {"PASS", "YES"}:
-        return "PASS"
-    if upper in {"FAIL", "NO"}:
-        return "FAIL"
-    raise ValueError(f'Invalid label string "{label}".  Must be one of YES,NO,PASS,FAIL')
+    if upper in {PASS_DEPRECATED, YES}:
+        return PASS_DEPRECATED
+    if upper in {FAIL_DEPRECATED, NO}:
+        return FAIL_DEPRECATED
+    raise ValueError(f'Invalid label string "{label}".  Must be one of {YES},{NO},{PASS_DEPRECATED},{FAIL_DEPRECATED}')

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -72,7 +72,8 @@ class Groundlight:
         self.detectors_api = DetectorsApi(self.api_client)
         self.image_queries_api = ImageQueriesApi(self.api_client)
 
-    def _post_process_image_query(self, iq: ImageQuery) -> ImageQuery:
+    @classmethod
+    def _post_process_image_query(cls, iq: ImageQuery) -> ImageQuery:
         """Post-process the image query so we don't use confusing internal labels.
 
         TODO: Get rid of this once we clean up the mapping logic server-side.

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -10,7 +10,7 @@ from openapi_client.api.detectors_api import DetectorsApi
 from openapi_client.api.image_queries_api import ImageQueriesApi
 from openapi_client.model.detector_creation_input import DetectorCreationInput
 
-from groundlight.binary_labels import convert_display_label_to_internal
+from groundlight.binary_labels import convert_display_label_to_internal, convert_internal_label_to_display
 from groundlight.config import API_TOKEN_VARIABLE_NAME, API_TOKEN_WEB_URL
 from groundlight.images import parse_supported_image_types
 from groundlight.internalapi import GroundlightApiClient, NotFoundError, sanitize_endpoint_url
@@ -71,6 +71,14 @@ class Groundlight:
         self.api_client = GroundlightApiClient(configuration)
         self.detectors_api = DetectorsApi(self.api_client)
         self.image_queries_api = ImageQueriesApi(self.api_client)
+
+    def _post_process_image_query(self, iq: ImageQuery) -> ImageQuery:
+        """Post-process the image query so we don't use confusing internal labels.
+
+        TODO: Get rid of this once we clean up the mapping logic server-side.
+        """
+        iq.result.label = convert_internal_label_to_display(iq, iq.result.label)
+        return iq
 
     def get_detector(self, id: Union[str, Detector]) -> Detector:  # pylint: disable=redefined-builtin
         if isinstance(id, Detector):
@@ -133,11 +141,15 @@ class Groundlight:
 
     def get_image_query(self, id: str) -> ImageQuery:  # pylint: disable=redefined-builtin
         obj = self.image_queries_api.get_image_query(id=id)
-        return ImageQuery.parse_obj(obj.to_dict())
+        iq = ImageQuery.parse_obj(obj.to_dict())
+        return self._post_process_image_query(iq)
 
     def list_image_queries(self, page: int = 1, page_size: int = 10) -> PaginatedImageQueryList:
         obj = self.image_queries_api.list_image_queries(page=page, page_size=page_size)
-        return PaginatedImageQueryList.parse_obj(obj.to_dict())
+        image_queries = PaginatedImageQueryList.parse_obj(obj.to_dict())
+        if image_queries.results is not None:
+            image_queries.results = [self._post_process_image_query(iq) for iq in image_queries.results]
+        return image_queries
 
     def submit_image_query(
         self,
@@ -167,7 +179,7 @@ class Groundlight:
         if wait:
             threshold = self.get_detector(detector).confidence_threshold
             image_query = self.wait_for_confident_result(image_query, confidence_threshold=threshold, timeout_sec=wait)
-        return image_query
+        return self._post_process_image_query(image_query)
 
     def wait_for_confident_result(
         self,
@@ -209,7 +221,7 @@ class Groundlight:
         """A new label to an image query.  This answers the detector's question.
         :param image_query: Either an ImageQuery object (returned from `submit_image_query`) or
         an image_query id as a string.
-        :param label: The string "Yes" or the string "No" in answer to the query.
+        :param label: The string "YES" or the string "NO" in answer to the query.
         """
         if isinstance(image_query, ImageQuery):
             image_query_id = image_query.id

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -2,7 +2,6 @@
 # ruff: noqa: F403,F405
 # pylint: disable=wildcard-import,unused-wildcard-import,redefined-outer-name,import-outside-toplevel
 from datetime import datetime
-from logging import getLogger
 
 import openapi_client
 import pytest
@@ -12,9 +11,6 @@ from groundlight.internalapi import NotFoundError
 from groundlight.optional_imports import *
 from groundlight.status_codes import is_user_error
 from model import Detector, ImageQuery, PaginatedDetectorList, PaginatedImageQueryList
-
-logger = getLogger(__name__)
-
 
 DEFAULT_CONFIDENCE_THRESHOLD = 0.9
 


### PR DESCRIPTION
The SDK should not be returning the confusing `PASS` or `FAIL` labels anymore.

I'm not a big fan of the mapper in the client, but I think it's an important fix for clarity in the short term.

Fixes #7 