### PR TITLE
Numpy arrays must be in BGR order not RGB - Issue #34

### DIFF
--- a/docs/docs/installation/libraries-numpy-pil.md
+++ b/docs/docs/installation/libraries-numpy-pil.md
@@ -22,10 +22,10 @@ import numpy as np
 img = np_img = np.random.uniform(0, 255, (600, 800, 3))
 ```
 
-Should you have an RGB array, you can reverse it with:
+If you have an RGB array, you must reverse the channel order before sending it to Groundlight, like:
 
 ```python notest
-rgb_img = bgr_img[:, :, ::-1]
+bgr_img = rgb_img[:, :, ::-1]
 ```
 
 

--- a/docs/docs/installation/libraries-numpy-pil.md
+++ b/docs/docs/installation/libraries-numpy-pil.md
@@ -11,7 +11,7 @@ wrong if you try to use these features.
 
 ## Numpy
 
-The Groundlight SDK can accept images as `numpy` arrays. They should be in the standard HWN format in RGB color order.
+The Groundlight SDK can accept images as `numpy` arrays. They should be in the standard HWN format in BGR color order, matching OpenCV standards.
 Pixel values should be from 0-255 (not 0.0-1.0 as floats). SO `uint8` data type is preferable since it saves memory.
 
 Here's sample code to create an 800x600 random image in numpy:
@@ -22,6 +22,13 @@ import numpy as np
 img = np_img = np.random.uniform(0, 255, (600, 800, 3))
 ```
 
+Should you have an RGB array, you can reverse it with:
+
+```python notest
+rgb_img = bgr_img[:, :, ::-1]
+```
+
+
 ## PIL
 
 The Groundlight SDK can accept PIL images directly in `submit_image_query`.
@@ -29,10 +36,3 @@ The Groundlight SDK can accept PIL images directly in `submit_image_query`.
 ## OpenCV
 
 OpenCV creates images that are stored as numpy arrays. So can send them to `submit_image_query` directly.
-<b>BUT!</b> OpenCV uses BGR color order, not RGB. You can reverse them as follows:
-
-```python notest
-rgb_img = bgr_img[:, :, ::-1]
-```
-
-See [Issue #34](https://github.com/groundlight/python-sdk/issues/34) for a discussion about OpenCV support.

--- a/docs/docs/installation/linux-windows-mac.md
+++ b/docs/docs/installation/linux-windows-mac.md
@@ -21,7 +21,7 @@ To install the Groundlight SDK using pip, run the following command in your term
 pip install groundlight
 ```
 
-If you're using `python3`, you might need to use `pip3` instead:
+If you're also using `python2` on your system, you might need to use `pip3` instead:
 
 ```bash
 pip3 install groundlight

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -149,7 +149,7 @@ class Groundlight:
         :param image: The image, in several possible formats:
           - filename (string) of a jpeg file
           - byte array or BytesIO or BufferedReader with jpeg bytes
-          - numpy array with values 0-255 and dimensions (H,W,3) in RGB order
+          - numpy array with values 0-255 and dimensions (H,W,3) in BGR order
             (Note OpenCV uses BGR not RGB. `img[:, :, ::-1]` will reverse the channels)
           - PIL Image
           Any binary format must be JPEG-encoded already.  Any pixel format will get

--- a/src/groundlight/images.py
+++ b/src/groundlight/images.py
@@ -49,7 +49,8 @@ def parse_supported_image_types(
         # Already in the right format
         return image
     if isinstance(image, np.ndarray):
-        return BytesIO(jpeg_from_numpy(image, jpeg_quality=jpeg_quality))
+        # Assume it is in BGR format from opencv
+        return BytesIO(jpeg_from_numpy(image[:, :, ::-1], jpeg_quality=jpeg_quality))
     raise TypeError(
         (
             "Unsupported type for image. Must be PIL, numpy (H,W,3) RGB, or a JPEG as a filename (str), bytes,"


### PR DESCRIPTION
Small fix to make image submission accept the bgr standard that opencv utilizes