### PR TITLE
Fixing bug in timing of polling for confident result

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: get code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
       - name: install python

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: get code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
       - name: install python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
     {include = "**/*.py", from = "src"},
 ]
 readme = "README.md"
-version = "0.8.0"
+version = "0.8.1"
 
 [tool.poetry.dependencies]
 certifi = "^2021.10.8"

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -72,8 +72,7 @@ class Groundlight:
         self.image_queries_api = ImageQueriesApi(self.api_client)
 
     def _fixup_image_query(self, iq: ImageQuery) -> ImageQuery:
-        """Process the wire-format image query to make it more usable.
-        """
+        """Process the wire-format image query to make it more usable."""
         # Note: This might go away once we clean up the mapping logic server-side.
         iq.result.label = convert_internal_label_to_display(iq, iq.result.label)
         return iq
@@ -204,9 +203,9 @@ class Groundlight:
         :param timeout_sec: The maximum number of seconds to wait.
         """
         # TODO: Add support for ImageQuery id instead of object.
-        start_time = time.time() 
+        start_time = time.time()
         next_delay = self.POLLING_INITIAL_DELAY
-        target_delay = 0
+        target_delay = 0.0
         image_query = self._fixup_image_query(image_query)
         while True:
             patience_so_far = time.time() - start_time
@@ -218,12 +217,15 @@ class Groundlight:
                 break
             target_delay = min(patience_so_far + next_delay, timeout_sec)
             sleep_time = max(target_delay - patience_so_far, 0)
-            logger.debug(f"Polling ({target_delay:.1f}/{timeout_sec:.0f}s) {image_query} until confidence>={confidence_threshold:.3f}")
+            logger.debug(
+                f"Polling ({target_delay:.1f}/{timeout_sec:.0f}s) {image_query} until"
+                f" confidence>={confidence_threshold:.3f}"
+            )
             time.sleep(sleep_time)
             next_delay *= self.POLLING_EXPONENTIAL_BACKOFF
             image_query = self.get_image_query(image_query.id)
             image_query = self._fixup_image_query(image_query)
-        return image_query    
+        return image_query
 
     def add_label(self, image_query: Union[ImageQuery, str], label: Union[Label, str]):
         """A new label to an image query.  This answers the detector's question.

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -71,12 +71,10 @@ class Groundlight:
         self.detectors_api = DetectorsApi(self.api_client)
         self.image_queries_api = ImageQueriesApi(self.api_client)
 
-    @classmethod
-    def _post_process_image_query(cls, iq: ImageQuery) -> ImageQuery:
-        """Post-process the image query so we don't use confusing internal labels.
-
-        TODO: Get rid of this once we clean up the mapping logic server-side.
+    def _fixup_image_query(self, iq: ImageQuery) -> ImageQuery:
+        """Process the wire-format image query to make it more usable.
         """
+        # Note: This might go away once we clean up the mapping logic server-side.
         iq.result.label = convert_internal_label_to_display(iq, iq.result.label)
         return iq
 
@@ -154,13 +152,13 @@ class Groundlight:
     def get_image_query(self, id: str) -> ImageQuery:  # pylint: disable=redefined-builtin
         obj = self.image_queries_api.get_image_query(id=id)
         iq = ImageQuery.parse_obj(obj.to_dict())
-        return self._post_process_image_query(iq)
+        return self._fixup_image_query(iq)
 
     def list_image_queries(self, page: int = 1, page_size: int = 10) -> PaginatedImageQueryList:
         obj = self.image_queries_api.list_image_queries(page=page, page_size=page_size)
         image_queries = PaginatedImageQueryList.parse_obj(obj.to_dict())
         if image_queries.results is not None:
-            image_queries.results = [self._post_process_image_query(iq) for iq in image_queries.results]
+            image_queries.results = [self._fixup_image_query(iq) for iq in image_queries.results]
         return image_queries
 
     def submit_image_query(
@@ -191,7 +189,7 @@ class Groundlight:
         if wait:
             threshold = self.get_detector(detector).confidence_threshold
             image_query = self.wait_for_confident_result(image_query, confidence_threshold=threshold, timeout_sec=wait)
-        return self._post_process_image_query(image_query)
+        return self._fixup_image_query(image_query)
 
     def wait_for_confident_result(
         self,
@@ -206,27 +204,26 @@ class Groundlight:
         :param timeout_sec: The maximum number of seconds to wait.
         """
         # TODO: Add support for ImageQuery id instead of object.
-        timeout_time = time.time() + timeout_sec
-        delay = self.POLLING_INITIAL_DELAY
-        while time.time() < timeout_time:
-            current_confidence = image_query.result.confidence
-            if current_confidence is None:
-                logging.debug("Image query with None confidence implies human label (for now)")
+        start_time = time.time() 
+        next_delay = self.POLLING_INITIAL_DELAY
+        target_delay = 0
+        image_query = self._fixup_image_query(image_query)
+        while True:
+            patience_so_far = time.time() - start_time
+            if image_query.result.confidence >= confidence_threshold:
+                logger.debug(f"Confident answer for {image_query} after {patience_so_far:.1f}s")
                 break
-            if current_confidence >= confidence_threshold:
-                logging.debug(f"Image query confidence {current_confidence:.3f} above {confidence_threshold:.3f}")
+            if patience_so_far >= timeout_sec:
+                logger.debug(f"Timeout after {timeout_sec:.0f}s waiting for {image_query}")
                 break
-            logger.debug(
-                (
-                    f"Polling for updated image_query because confidence {current_confidence:.3f} <"
-                    f" {confidence_threshold:.3f}"
-                ),
-            )
-            time_left = max(0, time.time() - timeout_time)
-            time.sleep(min(delay, time_left))
-            delay *= self.POLLING_EXPONENTIAL_BACKOFF
+            target_delay = min(patience_so_far + next_delay, timeout_sec)
+            sleep_time = max(target_delay - patience_so_far, 0)
+            logger.debug(f"Polling ({target_delay:.1f}/{timeout_sec:.0f}s) {image_query} until confidence>={confidence_threshold:.3f}")
+            time.sleep(sleep_time)
+            next_delay *= self.POLLING_EXPONENTIAL_BACKOFF
             image_query = self.get_image_query(image_query.id)
-        return image_query
+            image_query = self._fixup_image_query(image_query)
+        return image_query    
 
     def add_label(self, image_query: Union[ImageQuery, str], label: Union[Label, str]):
         """A new label to an image query.  This answers the detector's question.

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -71,7 +71,7 @@ class Groundlight:
         self.detectors_api = DetectorsApi(self.api_client)
         self.image_queries_api = ImageQueriesApi(self.api_client)
 
-    def _fixup_image_query(self, iq: ImageQuery) -> ImageQuery:
+    def _fixup_image_query(self, iq: ImageQuery) -> ImageQuery: # pylint: disable=no-self-use
         """Process the wire-format image query to make it more usable."""
         # Note: This might go away once we clean up the mapping logic server-side.
         iq.result.label = convert_internal_label_to_display(iq, iq.result.label)

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -13,7 +13,7 @@ from openapi_client.model.detector_creation_input import DetectorCreationInput
 from groundlight.binary_labels import Label, convert_display_label_to_internal, convert_internal_label_to_display
 from groundlight.config import API_TOKEN_VARIABLE_NAME, API_TOKEN_WEB_URL
 from groundlight.images import parse_supported_image_types
-from groundlight.internalapi import GroundlightApiClient, NotFoundError, sanitize_endpoint_url
+from groundlight.internalapi import GroundlightApiClient, NotFoundError, iq_is_confident, sanitize_endpoint_url
 from groundlight.optional_imports import Image, np
 
 logger = logging.getLogger("groundlight.sdk")
@@ -210,7 +210,7 @@ class Groundlight:
         image_query = self._fixup_image_query(image_query)
         while True:
             patience_so_far = time.time() - start_time
-            if image_query.result.confidence >= confidence_threshold:
+            if iq_is_confident(image_query, confidence_threshold):
                 logger.debug(f"Confident answer for {image_query} after {patience_so_far:.1f}s")
                 break
             if patience_so_far >= timeout_sec:

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -71,7 +71,7 @@ class Groundlight:
         self.detectors_api = DetectorsApi(self.api_client)
         self.image_queries_api = ImageQueriesApi(self.api_client)
 
-    def _fixup_image_query(self, iq: ImageQuery) -> ImageQuery: # pylint: disable=no-self-use
+    def _fixup_image_query(self, iq: ImageQuery) -> ImageQuery:  # pylint: disable=no-self-use
         """Process the wire-format image query to make it more usable."""
         # Note: This might go away once we clean up the mapping logic server-side.
         iq.result.label = convert_internal_label_to_display(iq, iq.result.label)

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -6,7 +6,7 @@ from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
-from model import Detector
+from model import Detector, ImageQuery
 from openapi_client.api_client import ApiClient
 
 from groundlight.status_codes import is_ok
@@ -57,6 +57,16 @@ def _generate_request_id():
     # But we don't want to just import ksuid because we want to avoid dependency bloat
     return "req_uu" + uuid.uuid4().hex
 
+
+def iq_is_confident(iq: ImageQuery, confidence_threshold: float) -> bool:
+    """Returns True if the image query's confidence is above threshold.
+    The only subtletie here is that currently confidence of None means 
+    human label, which is treated as confident.
+    """
+    if iq.label.confidence is None:
+        # Human label
+        return True
+    return iq.label.confidence >= confidence_threshold
 
 class InternalApiError(RuntimeError):
     # TODO: We need a better exception hierarchy

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -60,13 +60,14 @@ def _generate_request_id():
 
 def iq_is_confident(iq: ImageQuery, confidence_threshold: float) -> bool:
     """Returns True if the image query's confidence is above threshold.
-    The only subtletie here is that currently confidence of None means 
+    The only subtletie here is that currently confidence of None means
     human label, which is treated as confident.
     """
     if iq.label.confidence is None:
         # Human label
         return True
     return iq.label.confidence >= confidence_threshold
+
 
 class InternalApiError(RuntimeError):
     # TODO: We need a better exception hierarchy

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -53,8 +53,6 @@ def sanitize_endpoint_url(endpoint: Optional[str] = None) -> str:
 
 
 def _generate_request_id():
-    # TODO: use a ksuid instead of a uuid.  Most of our API uses ksuids for lots of reasons.
-    # But we don't want to just import ksuid because we want to avoid dependency bloat
     return "req_uu" + uuid.uuid4().hex
 
 
@@ -63,10 +61,10 @@ def iq_is_confident(iq: ImageQuery, confidence_threshold: float) -> bool:
     The only subtletie here is that currently confidence of None means
     human label, which is treated as confident.
     """
-    if iq.label.confidence is None:
+    if iq.result.confidence is None:
         # Human label
         return True
-    return iq.label.confidence >= confidence_threshold
+    return iq.result.confidence >= confidence_threshold
 
 
 class InternalApiError(RuntimeError):


### PR DESCRIPTION
The logic for calculating delays in polling was wrong, so it was in a tight-loop to poll.  Now the logic is fixed, and also the debug logs are more clear about what's going on.
