### PR TITLE
Changes the default detector for tests to not raise queries to labelers

### DIFF
--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -44,7 +44,8 @@ def fixture_detector(gl: Groundlight) -> Detector:
     """Creates a new Test detector."""
     name = f"Test {datetime.utcnow()}"  # Need a unique name
     query = "Is there a dog?"
-    return gl.create_detector(name=name, query=query)
+    pipeline_config = "never-review"
+    return gl.create_detector(name=name, query=query, pipeline_config=pipeline_config)
 
 
 @pytest.fixture(name="image_query")


### PR DESCRIPTION
To my understanding, tests for our labellers should be elsewhere such as the canary tests. Most of the tests here that hit labellers are designed to test something else, and we shouldn't care if a human labeller sees them.