### PR TITLE
Fix Deploy docs GitHub Action 

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -220,6 +220,10 @@ jobs:
     steps:
       - name: Get code
         uses: actions/checkout@v3
+      - name: Install poetry 
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
       - name: Setup npm
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Adds a step to install poetry in order to fix [this](https://github.com/groundlight/python-sdk/actions/runs/6513169090/job/17693451147). 