### PR TITLE
Small improvements to API docs

### DIFF
--- a/sphinx_docs/conf.py
+++ b/sphinx_docs/conf.py
@@ -7,8 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 
-import sys
 import os
+import sys
+
 import toml
 
 sys.path.insert(0, os.path.abspath("../src"))
@@ -39,6 +40,10 @@ extensions = ["sphinx.ext.autodoc", "sphinxcontrib.autodoc_pydantic"]
 
 templates_path = ["_templates"]
 exclude_patterns = []
+
+# Automatically add type annotations to the generated function signatures and descriptions. This
+# means we don't have to manually add :type: annotations into the docstrings.
+autodoc_typehints = "both"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/sphinx_docs/index.rst
+++ b/sphinx_docs/index.rst
@@ -4,24 +4,8 @@ Welcome to Groundlight Python SDK's documentation!
 
 For a detailed view of the source code, visit the `Groundlight SDK GitHub Repository <https://github.com/groundlight/python-sdk>`_.
 
-
-.. automodule:: groundlight.client 
-   :members:
-   :special-members: __init__
-   :exclude-members: ApiTokenError
-
-
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-   models 
-
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   models

--- a/sphinx_docs/models.rst
+++ b/sphinx_docs/models.rst
@@ -1,4 +1,13 @@
 
+Groundlight Client
+==================
+
+.. automodule:: groundlight.client 
+   :members:
+   :special-members: __init__
+   :exclude-members: ApiTokenError
+
+
 API Response Objects
 =====================
 

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -212,14 +212,18 @@ class Groundlight:
         # TODO: We may soon allow users to update the retrieved detector's fields.
         if existing_detector.query != query:
             raise ValueError(
-                f"Found existing detector with name={name} (id={existing_detector.id}) but the queries don't match."
-                f" The existing query is '{existing_detector.query}'.",
+                (
+                    f"Found existing detector with name={name} (id={existing_detector.id}) but the queries don't match."
+                    f" The existing query is '{existing_detector.query}'."
+                ),
             )
         if confidence_threshold is not None and existing_detector.confidence_threshold != confidence_threshold:
             raise ValueError(
-                f"Found existing detector with name={name} (id={existing_detector.id}) but the confidence"
-                " thresholds don't match. The existing confidence threshold is"
-                f" {existing_detector.confidence_threshold}.",
+                (
+                    f"Found existing detector with name={name} (id={existing_detector.id}) but the confidence"
+                    " thresholds don't match. The existing confidence threshold is"
+                    f" {existing_detector.confidence_threshold}."
+                ),
             )
         return existing_detector
 

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -73,14 +73,11 @@ class Groundlight:
         Constructs a Groundlight client.
 
         :param endpoint: optionally specify a different endpoint
-        :type endpoint: str
 
         :param api_token: use this API token for your API calls.
                         If unset, fallback to the environment variable "GROUNDLIGHT_API_TOKEN".
-        :type api_token: str
 
         :return: Groundlight client
-        :rtype: Groundlight
         """
         # Specify the endpoint
         self.endpoint = sanitize_endpoint_url(endpoint)
@@ -116,10 +113,8 @@ class Groundlight:
         Get a detector by id
 
         :param id: the detector id
-        :type id: str or Detector
 
         :return: Detector
-        :rtype: Detector
         """
 
         if isinstance(id, Detector):
@@ -133,10 +128,8 @@ class Groundlight:
         Get a detector by name
 
         :param name: the detector name
-        :type name: str
 
         :return: Detector
-        :rtype: Detector
         """
         return self.api_client._get_detector_by_name(name)  # pylint: disable=protected-access
 
@@ -145,13 +138,10 @@ class Groundlight:
         List out detectors you own
 
         :param page: the page number
-        :type page: int
 
         :param page_size: the page size
-        :type page_size: int
 
         :return: PaginatedDetectorList
-        :rtype: PaginatedDetectorList
         """
         obj = self.detectors_api.list_detectors(page=page, page_size=page_size)
         return PaginatedDetectorList.parse_obj(obj.to_dict())
@@ -168,19 +158,14 @@ class Groundlight:
         Create a new detector with a given name and query
 
         :param name: the detector name
-        :type name: str
 
         :param query: the detector query
-        :type query: str
 
         :param confidence_threshold: the confidence threshold
-        :type confidence_threshold: float
 
         :param pipeline_config: the pipeline config
-        :type pipeline_config: str
 
         :return: Detector
-        :rtype: Detector
         """
         detector_creation_input = DetectorCreationInput(name=name, query=query)
         if confidence_threshold is not None:
@@ -204,19 +189,14 @@ class Groundlight:
         config.
 
         :param name: the detector name
-        :type name: str
 
         :param query: the detector query
-        :type query: str
 
         :param confidence_threshold: the confidence threshold
-        :type confidence_threshold: float
 
         :param pipeline_config: the pipeline config
-        :type pipeline_config: str
 
         :return: Detector
-        :rtype: Detector
         """
         try:
             existing_detector = self.get_detector_by_name(name)
@@ -232,18 +212,14 @@ class Groundlight:
         # TODO: We may soon allow users to update the retrieved detector's fields.
         if existing_detector.query != query:
             raise ValueError(
-                (
-                    f"Found existing detector with name={name} (id={existing_detector.id}) but the queries don't match."
-                    f" The existing query is '{existing_detector.query}'."
-                ),
+                f"Found existing detector with name={name} (id={existing_detector.id}) but the queries don't match."
+                f" The existing query is '{existing_detector.query}'.",
             )
         if confidence_threshold is not None and existing_detector.confidence_threshold != confidence_threshold:
             raise ValueError(
-                (
-                    f"Found existing detector with name={name} (id={existing_detector.id}) but the confidence"
-                    " thresholds don't match. The existing confidence threshold is"
-                    f" {existing_detector.confidence_threshold}."
-                ),
+                f"Found existing detector with name={name} (id={existing_detector.id}) but the confidence"
+                " thresholds don't match. The existing confidence threshold is"
+                f" {existing_detector.confidence_threshold}.",
             )
         return existing_detector
 
@@ -252,10 +228,8 @@ class Groundlight:
         Get an image query by id
 
         :param id: the image query id
-        :type id: str
 
         :return: ImageQuery
-        :rtype: ImageQuery
         """
         obj = self.image_queries_api.get_image_query(id=id)
         iq = ImageQuery.parse_obj(obj.to_dict())
@@ -266,13 +240,10 @@ class Groundlight:
         List out image queries you own
 
         :param page: the page number
-        :type page: int
 
         :param page_size: the page size
-        :type page_size: int
 
         :return: PaginatedImageQueryList
-        :rtype: PaginatedImageQueryList
         """
         obj = self.image_queries_api.list_image_queries(page=page, page_size=page_size)
         image_queries = PaginatedImageQueryList.parse_obj(obj.to_dict())
@@ -296,7 +267,6 @@ class Groundlight:
         Evaluates an image with Groundlight.
 
         :param detector: the Detector object, or string id of a detector like `det_12345`
-        :type detector: Detector or str
 
         :param image: The image, in several possible formats:
           - filename (string) of a jpeg file
@@ -305,44 +275,35 @@ class Groundlight:
             (Note OpenCV uses BGR not RGB. `img[:, :, ::-1]` will reverse the channels)
           - PIL Image: Any binary format must be JPEG-encoded already.
             Any pixel format will get converted to JPEG at high quality before sending to service.
-        :type image: str or bytes or Image.Image or BytesIO or BufferedReader or np.ndarray
 
         :param wait: How long to poll (in seconds) for a confident answer. This is a client-side timeout.
-        :type wait: float
 
         :param patience_time: How long to wait (in seconds) for a confident answer for this image query.
             The longer the patience_time, the more likely Groundlight will arrive at a confident answer.
             Within patience_time, Groundlight will update ML predictions based on stronger findings,
             and, additionally, Groundlight will prioritize human review of the image query if necessary.
             This is a soft server-side timeout. If not set, use the detector's patience_time.
-        :type patience_time: float
 
         :param confidence_threshold: The confidence threshold to wait for.
             If not set, use the detector's confidence threshold.
-        :type confidence_threshold: float
 
         :param human_review: If `None` or `DEFAULT`, send the image query for human review
             only if the ML prediction is not confident.
             If set to `ALWAYS`, always send the image query for human review.
             If set to `NEVER`, never send the image query for human review.
-        :type human_review: str
 
         :param want_async: If True, the client will return as soon as the image query is submitted and will not wait for
             an ML/human prediction. The returned `ImageQuery` will have a `result` of None. Must set `wait` to 0 to use
             want_async.
-        :type want_async: bool
 
         :param inspection_id: Most users will omit this. For accounts with Inspection Reports enabled,
                             this is the ID of the inspection to associate with the image query.
-        :type inspection_id: str
 
         :param metadata: A dictionary or JSON string of custom key/value metadata to associate with
             the image query (limited to 1KB). You can retrieve this metadata later by calling
             `get_image_query()`.
-        :type metadata: dict or str
 
         :return: ImageQuery
-        :rtype: ImageQuery
         """
         if wait is None:
             wait = self.DEFAULT_WAIT
@@ -406,7 +367,6 @@ class Groundlight:
         of the detector is reached or the wait period has passed.
 
         :param detector: the Detector object, or string id of a detector like `det_12345`
-        :type detector: Detector or str
 
         :param image: The image, in several possible formats:
           - filename (string) of a jpeg file
@@ -416,22 +376,17 @@ class Groundlight:
           - PIL Image
           Any binary format must be JPEG-encoded already.  Any pixel format will get
           converted to JPEG at high quality before sending to service.
-        :type image: str or bytes or Image.Image or BytesIO or BufferedReader or np.ndarray
 
         :param confidence_threshold: The confidence threshold to wait for.
             If not set, use the detector's confidence threshold.
-        :type confidence_threshold: float
 
         :param wait: How long to wait (in seconds) for a confident answer.
-        :type wait: float
 
         :param metadata: A dictionary or JSON string of custom key/value metadata to associate with
             the image query (limited to 1KB). You can retrieve this metadata later by calling
             `get_image_query()`.
-        :type metadata: dict or str
 
         :return: ImageQuery
-        :rtype: ImageQuery
         """
         return self.submit_image_query(
             detector,
@@ -454,7 +409,6 @@ class Groundlight:
         Evaluates an image with Groundlight, getting the first answer Groundlight can provide.
 
         :param detector: the Detector object, or string id of a detector like `det_12345`
-        :type detector: Detector or str
 
         :param image: The image, in several possible formats:
           - filename (string) of a jpeg file
@@ -464,18 +418,14 @@ class Groundlight:
           - PIL Image
           Any binary format must be JPEG-encoded already.  Any pixel format will get
           converted to JPEG at high quality before sending to service.
-        :type image: str or bytes or Image.Image or BytesIO or BufferedReader or np.ndarray
 
         :param wait: How long to wait (in seconds) for any answer.
-        :type wait: float
 
         :param metadata: A dictionary or JSON string of custom key/value metadata to associate with
             the image query (limited to 1KB). You can retrieve this metadata later by calling
             `get_image_query()`.
-        :type metadata: dict or str
 
         :return: ImageQuery
-        :rtype: ImageQuery
         """
         iq = self.submit_image_query(
             detector,
@@ -503,7 +453,6 @@ class Groundlight:
         ImageQuery.
 
         :param detector: the Detector object, or string id of a detector like `det_12345`
-        :type detector: Detector or str
 
         :param image: The image, in several possible formats:
 
@@ -514,36 +463,29 @@ class Groundlight:
           - PIL Image: Any binary format must be JPEG-encoded already.
             Any pixel format will get converted to JPEG at high quality before sending to service.
 
-        :type image: str or bytes or Image.Image or BytesIO or BufferedReader or np.ndarray
 
         :param patience_time: How long to wait (in seconds) for a confident answer for this image query.
             The longer the patience_time, the more likely Groundlight will arrive at a confident answer.
             Within patience_time, Groundlight will update ML predictions based on stronger findings,
             and, additionally, Groundlight will prioritize human review of the image query if necessary.
             This is a soft server-side timeout. If not set, use the detector's patience_time.
-        :type patience_time: float
 
         :param confidence_threshold: The confidence threshold to wait for.
             If not set, use the detector's confidence threshold.
-        :type confidence_threshold: float
 
         :param human_review: If `None` or `DEFAULT`, send the image query for human review
             only if the ML prediction is not confident.
             If set to `ALWAYS`, always send the image query for human review.
             If set to `NEVER`, never send the image query for human review.
-        :type human_review: str
 
         :param inspection_id: Most users will omit this. For accounts with Inspection Reports enabled,
                             this is the ID of the inspection to associate with the image query.
-        :type inspection_id: str
 
         :param metadata: A dictionary or JSON string of custom key/value metadata to associate with
             the image query (limited to 1KB). You can retrieve this metadata later by calling
             `get_image_query()`.
-        :type metadata: dict or str
 
         :return: ImageQuery
-        :rtype: ImageQuery
 
 
         **Example usage**::
@@ -599,17 +541,13 @@ class Groundlight:
         Currently this is done by polling with an exponential back-off.
 
         :param image_query: An ImageQuery object to poll
-        :type image_query: ImageQuery or str
 
         :param confidence_threshold: The confidence threshold to wait for.
             If not set, use the detector's confidence threshold.
-        :type confidence_threshold: float
 
         :param timeout_sec: The maximum number of seconds to wait.
-        :type timeout_sec: float
 
         :return: ImageQuery
-        :rtype: ImageQuery
         """
         if confidence_threshold is None:
             if isinstance(image_query, str):
@@ -624,13 +562,10 @@ class Groundlight:
         Currently this is done by polling with an exponential back-off.
 
         :param image_query: An ImageQuery object to poll
-        :type image_query: ImageQuery or str
 
         :param timeout_sec: The maximum number of seconds to wait.
-        :type timeout_sec: float
 
         :return: ImageQuery
-        :rtype: ImageQuery
         """
         return self._wait_for_result(image_query, condition=iq_is_answered, timeout_sec=timeout_sec)
 
@@ -640,17 +575,13 @@ class Groundlight:
         """Performs polling with exponential back-off until the condition is met for the image query.
 
         :param image_query: An ImageQuery object to poll
-        :type image_query: ImageQuery or str
 
         :param condition: A callable that takes an ImageQuery and returns True or False
             whether to keep waiting for a better result.
-        :type condition: Callable
 
         :param timeout_sec: The maximum number of seconds to wait.
-        :type timeout_sec: float
 
         :return: ImageQuery
-        :rtype: ImageQuery
         """
         if isinstance(image_query, str):
             image_query = self.get_image_query(image_query)
@@ -682,13 +613,10 @@ class Groundlight:
 
         :param image_query: Either an ImageQuery object (returned from `submit_image_query`)
                             or an image_query id as a string.
-        :type image_query: ImageQuery or str
 
         :param label: The string "YES" or the string "NO" in answer to the query.
-        :type label: Label or str
 
         :return: None
-        :rtype: None
         """
         if isinstance(image_query, ImageQuery):
             image_query_id = image_query.id
@@ -708,7 +636,6 @@ class Groundlight:
         Starts an inspection report and returns the id of the inspection.
 
         :return: The unique identifier of the inspection.
-        :rtype: str
         """
         return self.api_client.start_inspection()
 
@@ -718,16 +645,12 @@ class Groundlight:
         Add/update inspection metadata with the user_provided_key and user_provided_value.
 
         :param inspection_id: The unique identifier of the inspection.
-        :type inspection_id: str
 
         :param user_provided_key: the key in the key/value pair for the inspection metadata.
-        :type user_provided_key: str
 
         :param user_provided_value: the value in the key/value pair for the inspection metadata.
-        :type user_provided_value: str
 
         :return: None
-        :rtype: None
         """
         self.api_client.update_inspection_metadata(inspection_id, user_provided_key, user_provided_value)
 
@@ -738,10 +661,8 @@ class Groundlight:
         indicates that the inspection was not successfully stopped.
 
         :param inspection_id: The unique identifier of the inspection.
-        :type inspection_id: str
 
         :return: "PASS" or "FAIL" depending on the result of the inspection.
-        :rtype: str
         """
         return self.api_client.stop_inspection(inspection_id)
 
@@ -750,10 +671,8 @@ class Groundlight:
         Updates the confidence threshold of a detector given a detector_id.
 
         :param detector_id: The id of the detector to update.
-        :type detector_id: str
 
         :param confidence_threshold: The new confidence threshold for the detector.
-        :type confidence_threshold: float
 
         :return None
         :rtype None

--- a/src/groundlight/encodings.py
+++ b/src/groundlight/encodings.py
@@ -8,20 +8,16 @@ def url_encode_dict(maybe_dict: Union[Dict, str], name: str, size_limit_bytes: O
     """Encode a dictionary as a URL-safe, base64-encoded JSON string.
 
     :param maybe_dict: The dictionary or JSON string to encode.
-    :type maybe_dict: dict or str
 
     :param name: The name of the dictionary, for use in the error message.
-    :type name: str
 
     :param size_limit_bytes: The maximum size of the dictionary, in bytes.
         If `None`, no size limit is enforced.
-    :type size_limit_bytes: int or None
 
     :raises TypeError: If `maybe_dict` is not a dictionary or JSON string.
     :raises ValueError: If `maybe_dict` is too large.
 
     :return: The URL-safe, base64-encoded JSON string.
-    :rtype: str
     """
     original_type = type(maybe_dict)
     if isinstance(maybe_dict, str):


### PR DESCRIPTION
- Use `autodoc_typehints` so we don't have to manually specify `:type <param>:` in our docstrings
- Add "Groundlight Client" to the sidebar

![Screenshot 2023-11-10 at 3 51 18 PM](https://github.com/groundlight/python-sdk/assets/4020875/ea85960c-4023-49b4-9474-46b61d7d3d48)
 