### PR TITLE
change framegrab blogpost image sources

### DIFF
--- a/docs/blog/2023-12-06-framegrab.md
+++ b/docs/blog/2023-12-06-framegrab.md
@@ -5,19 +5,19 @@ slug: introducing-framegrab
 authors:
   - name: Tim Huff
     title: Engineering intern at Groundlight
-    image_url: https://media.licdn.com/dms/image/D5603AQGQwDSbGUBQGA/profile-displayphoto-shrink_800_800/0/1666299654820?e=1707955200&v=beta&t=0V2Y83ZcAIvVnyGsm7HVmo9FK4S54cRdVu3jnOW1mRE
+    image_url: https://a-us.storyblok.com/f/1015187/1000x1000/06b25bf1a6/hufft.jpg
   - name: Blaise Munyampirwa
     title: Engineer at Groundlight
-    image_url: https://media.licdn.com/dms/image/C5603AQFn3zyJUMwMUA/profile-displayphoto-shrink_800_800/0/1656538661201?e=1707350400&v=beta&t=LtAkwTpt4avbqaQLSUdFerM7ydEfTTlZ3dOgmnDTpj4
+    image_url: https://a-us.storyblok.com/f/1015187/1000x1000/d12109465d/munyampirwab.jpg
   - name: Leo Dirac
     title: CTO and Co-founder at Groundlight
-    image_url: https://media.licdn.com/dms/image/C5603AQGtXilFu-aISw/profile-displayphoto-shrink_400_400/0/1646094305554?e=1707955200&v=beta&t=ZaD2WPrNTdLeWzeuSMjdgz08pEz92v0JyLvQHs4iA4w
+    image_url: https://a-us.storyblok.com/f/1015187/284x281/602a9c95c5/diracl.png
   - name: Tyler Romero 
     title: Senior Machine Learning Engineer
-    image_url: https://media.licdn.com/dms/image/D5603AQF0tC5-7i7o5g/profile-displayphoto-shrink_400_400/0/1667186510594?e=1707955200&v=beta&t=CAKXZuSxsNgLlNZxKUwREOlWeu7tz6GnKBHQCZ7U-d0 
+    image_url: https://a-us.storyblok.com/f/1015187/1000x1000/368053d79a/romerot.jpg 
   - name: Michael Vogelsong 
     title: Chief ML Scientist 
-    image_url: https://media.licdn.com/dms/image/C4E03AQGNcA6o2YP-yw/profile-displayphoto-shrink_200_200/0/1516836772974?e=1707955200&v=beta&t=sm1qBabL3bN1oZlO4iBvwuWhuqeMa0E-Jc4EqTtmJps
+    image_url: https://a-us.storyblok.com/f/1015187/1000x1000/c87b9d30f4/vogelsongm.jpg
 
 
 tags: [groundlight-extensions, framegrab]
@@ -26,7 +26,6 @@ hide_table_of_contents: false
 ---
 
 
-<!-- truncate -->
 
 At Groundlight, we continue to build infrastructure that allows our customers to easily use computer 
 vision without a pre-existing dataset for industrial inspection, retail analytics, mobile robotics, and 
@@ -35,6 +34,8 @@ introduce FrameGrab, a Python library designed to make it easy to grab frames fr
 cameras or streams. 
 
 FrameGrab supports generic USB cameras, RTSP streams, Basler USB cameras, Basler GigE cameras, and Intel RealSense depth cameras. 
+
+<!-- truncate -->
 
 
 ## Grabbing Camera Frames


### PR DESCRIPTION
The original source was from LinkedIn. Changing it to the official website. 