### PR TITLE
Deduplicate API client docs

### DIFF
--- a/sphinx_docs/models.rst
+++ b/sphinx_docs/models.rst
@@ -4,14 +4,6 @@ SDK Client
 .. autoclass:: groundlight.Groundlight 
    :members:
    :special-members: __init__
-
-
-Groundlight Client
-==================
-
-.. automodule:: groundlight.client 
-   :members:
-   :special-members: __init__
    :exclude-members: ApiTokenError
 
 


### PR DESCRIPTION
For some reason, we had two clients listed on our API docs page... This removes one of them.

![Screenshot 2024-01-18 at 4 46 02 PM](https://github.com/groundlight/python-sdk/assets/4020875/93b3227a-d458-49a2-be71-24a452a588ca)
