### PR TITLE
New release for detector metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
     {include = "**/*.py", from = "src"},
 ]
 readme = "README.md"
-version = "0.13.1"
+version = "0.13.2"
 
 [tool.poetry.dependencies]
 # For certifi, use ">=" instead of "^" since it upgrades its "major version" every year, not really following semver


### PR DESCRIPTION
We have a change that makes it possible to add up to 1KB of JSON metadata, but that's not yet on the public SDK version on PyPI. Increasing the version here before drafting the release. 