### PR TITLE
Add want_async and metadata params for image queries with inspection IDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
     {include = "**/*.py", from = "src"},
 ]
 readme = "README.md"
-version = "0.13.2"
+version = "0.13.3"
 
 [tool.poetry.dependencies]
 # For certifi, use ">=" instead of "^" since it upgrades its "major version" every year, not really following semver

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -264,7 +264,7 @@ class GroundlightApiClient(ApiClient):
 
         url = f"{self.configuration.host}/posichecks"
 
-        params: Dict[str, Union[str, float, bool, Dict[Any, Any]]] = {
+        params: Dict[str, Union[str, float, bool, Dict[Any, Any], None]] = {
             "inspection_id": inspection_id,
             "predictor_id": detector_id,
             "want_async": want_async,

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from enum import Enum
 from functools import wraps
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Optional, Union, Any
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
@@ -264,7 +264,7 @@ class GroundlightApiClient(ApiClient):
 
         url = f"{self.configuration.host}/posichecks"
 
-        params: Dict[str, Union[str, float, bool]] = {
+        params: Dict[str, Union[str, float, bool, Dict[Any, Any]]] = {
             "inspection_id": inspection_id,
             "predictor_id": detector_id,
             "want_async": want_async,

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -255,6 +255,8 @@ class GroundlightApiClient(ApiClient):
         inspection_id: str,
         patience_time: Optional[float] = None,
         human_review: str = "DEFAULT",
+        metadata: Optional[dict] = None,
+        want_async: Optional[bool] = False,
     ) -> str:
         """Submits an image query to the API and returns the ID of the image query.
         The image query will be associated to the inspection_id provided.
@@ -265,6 +267,8 @@ class GroundlightApiClient(ApiClient):
         params: Dict[str, Union[str, float, bool]] = {
             "inspection_id": inspection_id,
             "predictor_id": detector_id,
+            "metadata": metadata,
+            "want_async": want_async,
         }
         if patience_time is not None:
             params["patience_time"] = float(patience_time)

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -264,7 +264,7 @@ class GroundlightApiClient(ApiClient):
 
         url = f"{self.configuration.host}/posichecks"
 
-        params: Dict[str, Union[str, float, bool]] = {
+        params: Dict[str, Union[str, float, bool, None]] = {
             "inspection_id": inspection_id,
             "predictor_id": detector_id,
             "metadata": metadata,

--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -264,12 +264,14 @@ class GroundlightApiClient(ApiClient):
 
         url = f"{self.configuration.host}/posichecks"
 
-        params: Dict[str, Union[str, float, bool, None]] = {
+        params: Dict[str, Union[str, float, bool]] = {
             "inspection_id": inspection_id,
             "predictor_id": detector_id,
-            "metadata": metadata,
             "want_async": want_async,
         }
+
+        if metadata is not None:
+            params["metadata"] = metadata
         if patience_time is not None:
             params["patience_time"] = float(patience_time)
 

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -778,9 +778,7 @@ def test_update_detector_confidence_threshold_failure(gl: Groundlight, detector:
 
 
 @pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing detector metadata.")
-def test_submit_image_query_with_inspection_id_metadata_and_want_async(gl: Groundlight, 
-                                                                       detector: Detector,
-                                                                       image: str):
+def test_submit_image_query_with_inspection_id_metadata_and_want_async(gl: Groundlight, detector: Detector, image: str):
     inspection_id = gl.start_inspection()
     metadata = {"key": "value"}
     iq = gl.submit_image_query(

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -775,3 +775,22 @@ def test_update_detector_confidence_threshold_failure(gl: Groundlight, detector:
 
     with pytest.raises(ValueError):
         gl.update_detector_confidence_threshold(detector.id, -1)  # too low
+
+def test_submit_image_query_with_inspection_id_metadata_and_want_async(gl: Groundlight, detector: Detector):
+    inspection_id = gl.start_inspection()
+    metadata = {'key': 'value'}
+    iq = gl.submit_image_query(detector=detector.id, 
+                               image="test/assets/dog.jpeg", 
+                               human_review="NEVER", 
+                               inspection_id=inspection_id,
+                               metadata=metadata,
+                               want_async=True,
+                               wait=0,
+                               )
+    
+    iq = gl.get_image_query(iq.id)
+    iq = gl.wait_for_confident_result(iq.id)
+
+    assert iq.metadata == metadata
+    assert iq.result.label == Label.YES
+

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -776,6 +776,7 @@ def test_update_detector_confidence_threshold_failure(gl: Groundlight, detector:
     with pytest.raises(ValueError):
         gl.update_detector_confidence_threshold(detector.id, -1)  # too low
 
+@pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing metadata.")
 def test_submit_image_query_with_inspection_id_metadata_and_want_async(gl: Groundlight, detector: Detector):
     inspection_id = gl.start_inspection()
     metadata = {'key': 'value'}

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -777,12 +777,14 @@ def test_update_detector_confidence_threshold_failure(gl: Groundlight, detector:
         gl.update_detector_confidence_threshold(detector.id, -1)  # too low
 
 @pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing detector metadata.")
-def test_submit_image_query_with_inspection_id_metadata_and_want_async(gl: Groundlight, detector: Detector):
+def test_submit_image_query_with_inspection_id_metadata_and_want_async(gl: Groundlight, 
+                                                                       detector: Detector,
+                                                                       image: str):
     inspection_id = gl.start_inspection()
     metadata = {"key": "value"}
     iq = gl.submit_image_query(
         detector=detector.id,
-        image="test/assets/dog.jpeg",
+        image=image,
         human_review="NEVER",
         inspection_id=inspection_id,
         metadata=metadata,


### PR DESCRIPTION
Currently, the SDK does not accept `metadata` or `want_async` parameters on `Groundlight.submit_image_query`.

The following errors are raised:
```
TypeError: GroundlightApiClient.submit_image_query_with_inspection() got an unexpected keyword argument 'want_async'
```

```
TypeError: GroundlightApiClient.submit_image_query_with_inspection() got an unexpected keyword argument 'metadata'
```

This PR adds support for these parameters. 