### PR TITLE
Fail fast if API token or endpoint is invalid

### DIFF
--- a/docs/docs/building-applications/7-edge.md
+++ b/docs/docs/building-applications/7-edge.md
@@ -21,7 +21,7 @@ image queries will not appear in the cloud dashboard.
 
 To configure the Groundlight SDK to use the edge endpoint, you can either pass the endpoint URL to the Groundlight constructor like:
 
-```python
+```python notest
 from groundlight import Groundlight
 gl = Groundlight(endpoint="http://localhost:6717")
 ```

--- a/src/groundlight/cli.py
+++ b/src/groundlight/cli.py
@@ -55,8 +55,8 @@ def groundlight():
                 cli_func = class_func_to_cli(method)
                 cli_app.command()(cli_func)
         cli_app()
-    except ApiTokenError:
-        print(API_TOKEN_MISSING_HELP_MESSAGE)
+    except ApiTokenError as e:
+        print(e)
 
 
 if __name__ == "__main__":

--- a/src/groundlight/cli.py
+++ b/src/groundlight/cli.py
@@ -6,7 +6,7 @@ from typing_extensions import get_origin
 
 from groundlight import Groundlight
 from groundlight.client import ApiTokenError
-from groundlight.config import API_TOKEN_HELP_MESSAGE
+from groundlight.config import API_TOKEN_MISSING_HELP_MESSAGE
 
 cli_app = typer.Typer(
     no_args_is_help=True,
@@ -56,7 +56,7 @@ def groundlight():
                 cli_app.command()(cli_func)
         cli_app()
     except ApiTokenError:
-        print(API_TOKEN_HELP_MESSAGE)
+        print(API_TOKEN_MISSING_HELP_MESSAGE)
 
 
 if __name__ == "__main__":

--- a/src/groundlight/cli.py
+++ b/src/groundlight/cli.py
@@ -6,7 +6,6 @@ from typing_extensions import get_origin
 
 from groundlight import Groundlight
 from groundlight.client import ApiTokenError
-from groundlight.config import API_TOKEN_MISSING_HELP_MESSAGE
 
 cli_app = typer.Typer(
     no_args_is_help=True,

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -156,7 +156,7 @@ class Groundlight:
         except Exception as e:
             msg = (
                 f"Error connecting to Groundlight using API token '{self.api_token_prefix}...'"
-                f" at endpoint '{self.endpoint}'.  Endpoint might be invalid or offline?"
+                f" at endpoint '{self.endpoint}'.  Endpoint might be invalid or unreachable?"
             )
             raise GroundlightClientError(msg) from e
 

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -30,11 +30,11 @@ from groundlight.optional_imports import Image, np
 logger = logging.getLogger("groundlight.sdk")
 
 
-class GroundlightClientException(Exception):
+class GroundlightClientError(Exception):
     pass
 
 
-class ApiTokenError(GroundlightClientException):
+class ApiTokenError(GroundlightClientError):
     pass
 
 
@@ -156,7 +156,7 @@ class Groundlight:
                 f"Error connecting to Groundlight using API token '{self.api_token_prefix}...'"
                 f" at endpoint '{self.endpoint}'.  Endpoint might be invalid or offline?"
             )
-            raise GroundlightClientException(msg) from e
+            raise GroundlightClientError(msg) from e
 
     @staticmethod
     def _fixup_image_query(iq: ImageQuery) -> ImageQuery:

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -156,7 +156,8 @@ class Groundlight:
         except Exception as e:
             msg = (
                 f"Error connecting to Groundlight using API token '{self.api_token_prefix}...'"
-                f" at endpoint '{self.endpoint}'.  Endpoint might be invalid or unreachable?"
+                f" at endpoint '{self.endpoint}'.  Endpoint might be invalid or unreachable? "
+                f"Check https://status.groundlight.ai/ for service status."
             )
             raise GroundlightClientError(msg) from e
 

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -157,7 +157,7 @@ class Groundlight:
             msg = (
                 f"Error connecting to Groundlight using API token '{self.api_token_prefix}...'"
                 f" at endpoint '{self.endpoint}'.  Endpoint might be invalid or unreachable? "
-                f"Check https://status.groundlight.ai/ for service status."
+                "Check https://status.groundlight.ai/ for service status."
             )
             raise GroundlightClientError(msg) from e
 

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -107,12 +107,14 @@ class Groundlight:
         self.endpoint = sanitize_endpoint_url(endpoint)
         configuration = Configuration(host=self.endpoint)
 
-        if api_token is None:
+        if not api_token:
             try:
                 # Retrieve the API token from environment variable
                 api_token = os.environ[API_TOKEN_VARIABLE_NAME]
             except KeyError as e:
                 raise ApiTokenError(API_TOKEN_MISSING_HELP_MESSAGE) from e
+            if not api_token:
+                raise ApiTokenError("No API token found.  GROUNDLIGHT_API_TOKEN environment variable is set but blank")
         self.api_token_prefix = api_token[:12]
 
         should_disable_tls_verification = disable_tls_verification

--- a/src/groundlight/config.py
+++ b/src/groundlight/config.py
@@ -7,7 +7,7 @@ DISABLE_TLS_VARIABLE_NAME = "DISABLE_TLS_VERIFY"
 
 __all__ = ["API_TOKEN_WEB_URL", "API_TOKEN_VARIABLE_NAME", "DEFAULT_ENDPOINT", "DISABLE_TLS_VARIABLE_NAME"]
 
-API_TOKEN_HELP_MESSAGE = (
+API_TOKEN_MISSING_HELP_MESSAGE = (
     "No API token found. Please put your token in an environment variable "
     f'named "{API_TOKEN_VARIABLE_NAME}". If you don\'t have a token, you can '
     f"create one at {API_TOKEN_WEB_URL}"


### PR DESCRIPTION
When a SDK client is instantiated, immediately check connectivity to verify API token and endpoint.  Give a helpful error message if something is wrong.

This fixes #38 