### PR TITLE
Restoring timeout functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
     {include = "**/*.py", from = "src"},
 ]
 readme = "README.md"
-version = "0.14.0"
+version = "0.14.1"
 
 [tool.poetry.dependencies]
 # For certifi, use ">=" instead of "^" since it upgrades its "major version" every year, not really following semver

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -427,14 +427,15 @@ class Groundlight:
 
         image_bytesio: ByteStreamWrapper = parse_supported_image_types(image)
 
-        params = {"detector_id": detector_id, "body": image_bytesio}
+        params = {"detector_id": detector_id, "body": image_bytesio, "_request_timeout": DEFAULT_REQUEST_TIMEOUT}
+
         if patience_time is not None:
             params["patience_time"] = patience_time
 
         if human_review is not None:
             params["human_review"] = human_review
 
-        if inspection_id is not None:
+        if inspection_id:  # consider an empty string to mean there is no inspection
             params["inspection_id"] = inspection_id
 
         if want_async is True:

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -39,7 +39,7 @@ logger = logging.getLogger("groundlight.sdk")
 # Set urllib3 request timeout to something modern and fast.
 # The system defaults can be stupidly long
 # It used to take >8 min to timeout to a bad IP address
-DEFAULT_REQUEST_TIMEOUT = 5
+DEFAULT_REQUEST_TIMEOUT = 10 # seconds
 
 
 class GroundlightClientError(Exception):

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -39,7 +39,7 @@ logger = logging.getLogger("groundlight.sdk")
 # Set urllib3 request timeout to something modern and fast.
 # The system defaults can be stupidly long
 # It used to take >8 min to timeout to a bad IP address
-DEFAULT_REQUEST_TIMEOUT = 10 # seconds
+DEFAULT_REQUEST_TIMEOUT = 10  # seconds
 
 
 class GroundlightClientError(Exception):

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -796,3 +796,14 @@ def test_submit_image_query_with_inspection_id_metadata_and_want_async(gl: Groun
 
     assert iq.metadata == metadata
     assert iq.result.label == Label.YES
+
+def test_submit_image_query_with_empty_inspection_id(gl: Groundlight, detector: Detector, image: str):
+    """The URCap submits the inspection_id as an empty string when there is no active inspection.
+    This test ensures that this behavior is allowed and does not raise an exception.
+    """
+    gl.submit_image_query(
+        detector=detector.id,
+        image=image,
+        human_review="NEVER",
+        inspection_id='',
+    )


### PR DESCRIPTION
In https://github.com/groundlight/python-sdk/pull/168, Leo added faster HTTP timeouts, which was very helpful because the defaults are way too long.

In https://github.com/groundlight/python-sdk/pull/164, I was overzealous in my code deletion and accidentally removed it. This PR restores it.

Also, I found a breaking change between 0.14.0 and the RPC server/URCap. When there is no active inspection on the URCap, it sends an empty string for the inspection_id. URScript does not have the notion of None or null, or even optional arguments, so this seems to be the best we can do. Previously, the API would accept an empty string for the inspection_id, but the new API endpoint returns the following response: HTTP response body: {"inspection_id":["This field may not be blank."]}

This has been tested on the URCap/RPC server and works as expected. 