### PR TITLE
matrix test fix for v0.15.0

### DIFF
--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -13,6 +13,7 @@ def test_create_action(gl: ExperimentalApi):
         gl.get_rule(rule.id)
 
 
+@pytest.mark.skip(reason="actions are global on an account, the test matrix will run multiple tests that collide")  # type: ignore
 def test_get_all_actions(gl: ExperimentalApi):
     num_test_rules = 13  # needs to be larger than the default page size
     gl.ITEMS_PER_PAGE = 10

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -13,7 +13,7 @@ def test_create_action(gl: ExperimentalApi):
         gl.get_rule(rule.id)
 
 
-@pytest.mark.skip(reason="actions are global on an account, the test matrix will run multiple tests that collide")  # type: ignore
+@pytest.mark.skip(reason="actions are global on account, the test matrix collides with itself")  # type: ignore
 def test_get_all_actions(gl: ExperimentalApi):
     num_test_rules = 13  # needs to be larger than the default page size
     gl.ITEMS_PER_PAGE = 10


### PR DESCRIPTION
because users only have one set of actions, this action test if run by the same user at the same time will fail.

I previously tried to fix this by making detectors unique, but that won't help since actions aren't grouped by detector