### PR TITLE
[PK-3193] - Fix redirect with the Groundlight logo and change the script for Google Analytics

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -108,7 +108,7 @@ const config = {
         logo: {
           alt: "Groundlight Logo",
           src: "img/favicon-32x32.png",
-          to: "/python-sdk/",
+          href: "/python-sdk/",
         },
         items: [
           {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -53,8 +53,8 @@ const config = {
           // the second "docs" is the subdir within the repo
           // there will be a third one for real URLs.  :)
         },
-        googleTagManager: {
-          containerId: "GTM-5MV4R9FV",
+        gtag: {
+          trackingID: 'G-G0XW52NM2K',
         },
         blog: {
           showReadingTime: true,

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -108,7 +108,7 @@ const config = {
         logo: {
           alt: "Groundlight Logo",
           src: "img/favicon-32x32.png",
-          href: "https://code.groundlight.ai/",
+          to: "/python-sdk/",
         },
         items: [
           {


### PR DESCRIPTION
This change is to redirect to the index page instead of opening a new tab when the user clicks on the Groundlight logo.