### PR TITLE
Skipped detector metadata testing for edge

### DIFF
--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -174,7 +174,7 @@ def test_create_detector_with_confidence_threshold(gl: Groundlight):
         retrieved_detector.confidence_threshold == confidence_threshold
     ), "We expected to retrieve the existing detector's confidence, but got a different value."
 
-
+@pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing detector metadata.")
 def test_create_detector_with_everything(gl: Groundlight):
     name = f"Test {datetime.utcnow()}"  # Need a unique name
     query = "Is there a dog?"

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -174,6 +174,7 @@ def test_create_detector_with_confidence_threshold(gl: Groundlight):
         retrieved_detector.confidence_threshold == confidence_threshold
     ), "We expected to retrieve the existing detector's confidence, but got a different value."
 
+
 @pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing detector metadata.")
 def test_create_detector_with_everything(gl: Groundlight):
     name = f"Test {datetime.utcnow()}"  # Need a unique name


### PR DESCRIPTION
This PR just add a line to skip the detector metadata test for `edge-endpoint` since it is not supported.