### PR TITLE
Python3.12 pillow dependencies

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -130,9 +130,10 @@ jobs:
         python-version: [
             #"3.6",   # Default on Ubuntu18.04 but openapi-generator fails
             # "3.7",  # Removed support as of 0.17
-            "3.8",
-            "3.9",
-            "3.10",
+            # TEMP
+            # "3.8",
+            # "3.9",
+            # "3.10",
             "3.11",
             "3.12",
           ]

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -117,9 +117,9 @@ jobs:
       github.ref == 'refs/heads/main' ||
       startsWith(github.ref, 'refs/tags/v') ||
       endsWith(github.ref, '-fulltest')
-    needs:
-      - test-simple
-      - test-docs
+    # needs:
+    #   - test-simple
+    #   - test-docs
     runs-on: ubuntu-latest
     strategy:
       # fail-fast=false works best for flaky tests with manual "retry failed".
@@ -140,6 +140,13 @@ jobs:
     steps:
       - name: get code
         uses: actions/checkout@v4
+        # Pillow may need these to function
+      - name: install potential system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev
+          libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk
+          libharfbuzz-dev libfribidi-dev libxcb1-dev
       - name: install modern python for poetry
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -145,8 +145,8 @@ jobs:
       - name: install potential system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev
-          libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk
+          sudo apt-get install libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev \
+          libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
           libharfbuzz-dev libfribidi-dev libxcb1-dev
       - name: install modern python for poetry
         uses: actions/setup-python@v4

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -113,13 +113,13 @@ jobs:
   # - releases
   # - branch names ending with "-fulltest"
   test-comprehensive:
-    # if: >-
-    #   github.ref == 'refs/heads/main' ||
-    #   startsWith(github.ref, 'refs/tags/v') ||
-    #   endsWith(github.ref, '-fulltest')
-    # needs:
-    #   - test-simple
-    #   - test-docs
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/tags/v') ||
+      endsWith(github.ref, '-fulltest')
+    needs:
+      - test-simple
+      - test-docs
     runs-on: ubuntu-latest
     strategy:
       # fail-fast=false works best for flaky tests with manual "retry failed".
@@ -130,10 +130,9 @@ jobs:
         python-version: [
             #"3.6",   # Default on Ubuntu18.04 but openapi-generator fails
             # "3.7",  # Removed support as of 0.17
-            # TEMP
-            # "3.8",
-            # "3.9",
-            # "3.10",
+            "3.8",
+            "3.9",
+            "3.10",
             "3.11",
             "3.12",
           ]

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -113,10 +113,10 @@ jobs:
   # - releases
   # - branch names ending with "-fulltest"
   test-comprehensive:
-    if: >-
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/tags/v') ||
-      endsWith(github.ref, '-fulltest')
+    # if: >-
+    #   github.ref == 'refs/heads/main' ||
+    #   startsWith(github.ref, 'refs/tags/v') ||
+    #   endsWith(github.ref, '-fulltest')
     # needs:
     #   - test-simple
     #   - test-docs


### PR DESCRIPTION
I'm confused as to why this stopped working in the first place. But the package install matches the recommendation from Pillow [here](https://pillow.readthedocs.io/en/stable/installation/building-from-source.html#external-libraries)
 