### PR TITLE
dropping python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
     {include = "**/*.py", from = "src"},
 ]
 readme = "README.md"
-version = "0.18.4"
+version = "0.19.0"
 
 [tool.poetry.dependencies]
 # For certifi, use ">=" instead of "^" since it upgrades its "major version" every year, not really following semver
@@ -17,7 +17,7 @@ certifi = ">=2023.7.22"
 frozendict = "^2.3.2"
 pillow = ">=9.0.0" # TODO: We may want to mark pillow (and numpy) as extra (https://python-poetry.org/docs/master/pyproject#extras)
 pydantic = ">=2.0,<3.0.0"
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 python-dateutil = "^2.9.0"
 requests = "^2.28.2"
 typer = "^0.12.3"


### PR DESCRIPTION
Python 3.8 is past EOL, so the Groundlight SDK will no longer support 3.8