### PR TITLE
Fix Python 3.13 CICD issues by updating packages

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -119,7 +119,8 @@ jobs:
     if: >-
       github.ref == 'refs/heads/main' ||
       startsWith(github.ref, 'refs/tags/v') ||
-      endsWith(github.ref, '-fulltest')
+      endsWith(github.ref, '-fulltest') ||
+      endsWith(github.ref, '-from-tests-temp')
     needs:
       - test-simple
       - test-docs
@@ -138,7 +139,7 @@ jobs:
             "3.10",
             "3.11",
             "3.12",
-            # "3.13",  # TODO: fix poetry install issue with 3.13
+            "3.13",
           ]
         install_extras: [true, false]
     steps:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -119,8 +119,7 @@ jobs:
     if: >-
       github.ref == 'refs/heads/main' ||
       startsWith(github.ref, 'refs/tags/v') ||
-      endsWith(github.ref, '-fulltest') ||
-      endsWith(github.ref, '-from-tests-temp')
+      endsWith(github.ref, '-fulltest')
     needs:
       - test-simple
       - test-docs

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -138,7 +138,7 @@ jobs:
             "3.10",
             "3.11",
             "3.12",
-            "3.13",
+            # "3.13",  # TODO: fix poetry install issue with 3.13
           ]
         install_extras: [true, false]
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ version = "0.19.0"
 # For certifi, use ">=" instead of "^" since it upgrades its "major version" every year, not really following semver
 certifi = ">=2023.7.22"
 frozendict = "^2.3.2"
-pillow = ">=9.0.0" # TODO: We may want to mark pillow (and numpy) as extra (https://python-poetry.org/docs/master/pyproject#extras)
-pydantic = ">=2.0,<3.0.0"
+pillow = ">=11.0.0" # TODO: We may want to mark pillow (and numpy) as extra (https://python-poetry.org/docs/master/pyproject#extras)
+pydantic = "^2.0.0"
 python = ">=3.9,<4.0"
 python-dateutil = "^2.9.0"
 requests = "^2.28.2"
@@ -42,14 +42,14 @@ types-requests = "^2.28.11.17"
 
 [tool.poetry.group.sphinx-deps.dependencies]
 # These are extra / stricter dependencies required to build the API reference docs
-Sphinx = {version = "7.2.6", python = ">=3.9.0,<4.0"}
-autodoc-pydantic = {version = "2.0.1", python = ">=3.9.0,<4.0"}
-pillow = "^9.0.0"
-pydantic = "^2.0"
-python = ">=3.9.0,<4.0"
+Sphinx = {version = "^7.2.6", python = ">=3.9,<4.0"}
+autodoc-pydantic = {version = "^2.0.1", python = ">=3.9,<4.0"}
+pillow = "^11.0.0"
+pydantic = "^2.0.0"
+python = ">=3.9,<4.0"
 python-dateutil = "^2.8.2"
-sphinx-rtd-theme = {version = "1.3.0", python = ">=3.9.0,<4.0"}
-toml = "0.10.2"
+sphinx-rtd-theme = {version = "^1.3.0", python = ">=3.9,<4.0"}
+toml = "^0.10.2"
 
 [tool.poetry.scripts]
 groundlight = "groundlight.cli:groundlight"


### PR DESCRIPTION
Pillow 11 is the first version that supports Python 3.13, using pillow 9 broke test-comprehensive for the Python 3.13 part of the matrix.

Confirmation it works: https://github.com/groundlight/python-sdk/actions/runs/12150031217/job/33882229025?pr=283