### PR TITLE
Register markers to avoid pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,4 +85,5 @@ requires = ["poetry-core>=1.2.0"]
 [tool.pytest.ini_options]
 markers = [
     "skip_for_edge_endpoint",
+    "run_only_for_edge_endpoint",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,8 @@ trailing_comma_inline_array = true
 [build-system]
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.2.0"]
+
+[tool.pytest.ini_options]
+markers = [
+    "skip_for_edge_endpoint",
+]


### PR DESCRIPTION
Previously we'd get a bunch of warnings like this when running tests:

```
test/integration/test_groundlight.py:373
  /home/ubuntu/ptdev/python-sdk/test/integration/test_groundlight.py:373: PytestUnknownMarkWarning: Unknown pytest.mark.skip_for_edge_endpoint - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing detector metadata.")
```

According to [the docs](https://docs.pytest.org/en/stable/how-to/mark.html), unregistered markers will always produce these warnings. By registering our two custom markers, we don't get these warnings anymore.