### PR TITLE
Create multiple actions on alert

### DIFF
--- a/src/groundlight/experimental_api.py
+++ b/src/groundlight/experimental_api.py
@@ -143,12 +143,12 @@ class ExperimentalApi(Groundlight):
 
             gl = ExperimentalApi()
 
-            # Create an action for a rule
+            # Create an action for an alert
             action = gl.make_action("EMAIL", "example@example.com", include_image=True)
 
         :param channel: The notification channel to use. One of "EMAIL" or "TEXT"
         :param recipient: The email address or phone number to send notifications to
-        :param include_image: Whether to include the triggering image in notifications
+        :param include_image: Whether to include the triggering image in action message
         """
         return Action(
             channel=channel,
@@ -176,7 +176,7 @@ class ExperimentalApi(Groundlight):
         such as when a detector's prediction changes or maintains a particular state.
 
         .. note::
-            Currently, only binary mode detectors (YES/NO answers) are supported for notification rules.
+            Currently, only binary mode detectors (YES/NO answers) are supported for alerts.
 
         **Example usage**::
 
@@ -204,9 +204,9 @@ class ExperimentalApi(Groundlight):
                 actions=[action1, action2]
             )
 
-        :param detector: The detector ID or Detector object to add the rule to
-        :param name: A unique name to identify this rule
-        :param enabled: Whether the rule should be active when created (default True)
+        :param detector: The detector ID or Detector object to add the alert to
+        :param name: A unique name to identify this alert
+        :param enabled: Whether the alert should be active when created (default True)
         :param snooze_time_enabled: Enable notification snoozing to prevent alert spam (default False)
         :param snooze_time_value: Duration of snooze period (default 3600)
         :param snooze_time_unit: Unit for snooze duration - "SECONDS", "MINUTES", "HOURS", or "DAYS" (default "SECONDS")

--- a/src/groundlight/experimental_api.py
+++ b/src/groundlight/experimental_api.py
@@ -156,7 +156,7 @@ class ExperimentalApi(Groundlight):
             include_image=include_image,
         )
 
-    def create_alert(
+    def create_alert( # pylint: disable=too-many-locals  # noqa: PLR0913
         self,
         detector: Union[str, Detector],
         name,

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -37,7 +37,8 @@ def is_valid_display_result(result: Any) -> bool:
         and not isinstance(result, MultiClassificationResult)
     ):
         return False
-    if not is_valid_display_label(result.label):
+
+    if isinstance(result, BinaryClassificationResult) and not is_valid_display_label(result.label):
         return False
     return True
 

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -52,3 +52,18 @@ def test_delete_action(gl_experimental: ExperimentalApi):
     gl_experimental.delete_rule(rule.id)
     with pytest.raises(NotFoundException) as _:
         gl_experimental.get_rule(rule.id)
+
+
+def test_create_alert_multiple_actions(gl_experimental: ExperimentalApi):
+    name = f"Test {datetime.utcnow()}"
+    det = gl_experimental.get_or_create_detector(name, "test_query")
+    condition = gl_experimental.make_condition("CHANGED_TO", {"label": "YES"})
+    action1 = gl_experimental.make_action("EMAIL", "test@groundlight.ai", False)
+    action2 = gl_experimental.make_action("EMAIL", "test@groundlight.ai", False)
+    alert = gl_experimental.create_alert(
+        det,
+        f"test_alert_{name}",
+        condition,
+        [action1, action2],
+    )
+    assert len(alert.action.root) == 2

--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -60,10 +60,11 @@ def test_create_alert_multiple_actions(gl_experimental: ExperimentalApi):
     condition = gl_experimental.make_condition("CHANGED_TO", {"label": "YES"})
     action1 = gl_experimental.make_action("EMAIL", "test@groundlight.ai", False)
     action2 = gl_experimental.make_action("EMAIL", "test@groundlight.ai", False)
+    actions = [action1, action2]
     alert = gl_experimental.create_alert(
         det,
         f"test_alert_{name}",
         condition,
-        [action1, action2],
+        actions,
     )
-    assert len(alert.action.root) == 2
+    assert len(alert.action.root) == len(actions)


### PR DESCRIPTION
A followup for later, we will completely replace 'rule' with 'alert'. Once renamed we can move alert functions into the standard client. This requires a bit of backend modelling updates.

I'm not a huge fan of root as the attribute of ActionList, but that matches the style of datamodel-codegen.