### PR TITLE
Fix bug in wait_for_confident_result

### DIFF
--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -1004,6 +1004,8 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes
         """
         if isinstance(image_query, str):
             image_query = self.get_image_query(image_query)
+
+        if confidence_threshold is None:
             confidence_threshold = self.get_detector(image_query.detector_id).confidence_threshold
 
         confidence_above_thresh = partial(iq_is_confident, confidence_threshold=confidence_threshold)  # type: ignore


### PR DESCRIPTION
The `confidence_threshold` parameter defaults to `None`, and the docstring states that if it is `None` then the detector's confidence threshold will be used. However, it currently only fetches the detector's confidence threshold if the value for `image_query` is a string - if you pass it an `ImageQuery` object, `confidence_threshold` will still be `None` when passed to `iq_is_confident`, which will then error when trying to do `iq.result.confidence >= confidence_threshold`.

This fixes it so it will always fetch the detector's confidence threshold if the inputted `confidence_threshold` is None.