### PR TITLE
update POETRY_VERSION

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  POETRY_VERSION: "1.7.1"
+  POETRY_VERSION: "2.1.3"
 jobs:
   # Run our linter on every push to the repository.
   lint:


### PR DESCRIPTION
1.7.1 is from 2023. New versions of poetry don't have the incorrect calls to virtualenv in them.