### PR TITLE
disable mypy linting errors

### DIFF
--- a/src/groundlight/optional_imports.py
+++ b/src/groundlight/optional_imports.py
@@ -35,7 +35,7 @@ try:
 except ImportError as e:
     np = UnavailableModule(e)
     # Expose np.ndarray so type-hinting looks normal
-    np.ndarray = np  # pylint: disable=attribute-defined-outside-init
+    np.ndarray = np  # pylint: disable=attribute-defined-outside-init  # type: ignore[attr-defined]
     MISSING_NUMPY = True
 
 try:
@@ -46,7 +46,7 @@ try:
 except ImportError as e:
     PIL = UnavailableModule(e)
     Image = PIL
-    Image.Image = PIL  # for type-hinting; pylint: disable=attribute-defined-outside-init
+    Image.Image = PIL  # for type-hinting; pylint: disable=attribute-defined-outside-init  # type: ignore[attr-defined]
     MISSING_PIL = True
 
 

--- a/src/groundlight/optional_imports.py
+++ b/src/groundlight/optional_imports.py
@@ -35,7 +35,7 @@ try:
 except ImportError as e:
     np = UnavailableModule(e)
     # Expose np.ndarray so type-hinting looks normal
-    np.ndarray = np  # pylint: disable=attribute-defined-outside-init  # type: ignore
+    np.ndarray = np  # type: ignore # pylint: disable=attribute-defined-outside-init
     MISSING_NUMPY = True
 
 try:
@@ -46,7 +46,7 @@ try:
 except ImportError as e:
     PIL = UnavailableModule(e)
     Image = PIL
-    Image.Image = PIL  # for type-hinting; pylint: disable=attribute-defined-outside-init  # type: ignore
+    Image.Image = PIL  # type: ignore # for type-hinting; pylint: disable=attribute-defined-outside-init
     MISSING_PIL = True
 
 

--- a/src/groundlight/optional_imports.py
+++ b/src/groundlight/optional_imports.py
@@ -35,7 +35,7 @@ try:
 except ImportError as e:
     np = UnavailableModule(e)
     # Expose np.ndarray so type-hinting looks normal
-    np.ndarray = np  # pylint: disable=attribute-defined-outside-init  # type: ignore[attr-defined]
+    np.ndarray = np  # pylint: disable=attribute-defined-outside-init  # type: ignore
     MISSING_NUMPY = True
 
 try:
@@ -46,7 +46,7 @@ try:
 except ImportError as e:
     PIL = UnavailableModule(e)
     Image = PIL
-    Image.Image = PIL  # for type-hinting; pylint: disable=attribute-defined-outside-init  # type: ignore[attr-defined]
+    Image.Image = PIL  # for type-hinting; pylint: disable=attribute-defined-outside-init  # type: ignore
     MISSING_PIL = True
 
 


### PR DESCRIPTION
Mypy updated end of May and is now stricter on defining new attributes on classes. This just adds ignore statements to keep our tests passing