### PR TITLE
Remove unnecessary call to delete all rules to reduce concurrent test flakiness

### DIFF
--- a/test/unit/test_actions.py
+++ b/test/unit/test_actions.py
@@ -7,7 +7,6 @@ from groundlight_openapi_client.exceptions import NotFoundException
 
 def test_create_action(gl_experimental: ExperimentalApi):
     # We first clear out any rules in case the account has any left over from a previous test
-    gl_experimental.delete_all_rules()
     name = f"Test {datetime.utcnow()}"
     det = gl_experimental.get_or_create_detector(name, "test_query")
     rule = gl_experimental.create_rule(det, f"test_rule_{name}", "EMAIL", "test@example.com")


### PR DESCRIPTION
If two instances of tests were running on the same account in parallel, it's possible for delete all rules to collide with itself. We removed this previously for most of the other tests, one case of it appears to have been left in