### PR TITLE
Stop potential race condition in test

### DIFF
--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -885,6 +885,8 @@ def test_delete_detector(gl: Groundlight):
     detector2 = gl.create_detector(name=name2, query=query, pipeline_config=pipeline_config)
     gl.submit_image_query(detector2, "test/assets/dog.jpeg")
 
+    time.sleep(10)
+
     # Delete using detector ID string
     gl.delete_detector(detector2.id)
 


### PR DESCRIPTION
If Groundlight is still processing an image query and the detector is deleted, it can lead to undefined behavior