### PR TITLE
Enable configuring HTTP transport retry behavior and add `request_timeout` parameter to `get_detector`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ python = ">=3.9,<4.0"
 python-dateutil = "^2.9.0"
 requests = "^2.28.2"
 typer = "^0.15.4"
-urllib3 = "^1.26.9"
+urllib3 = "^2.5.0"
 
 [tool.poetry.group.dev.dependencies]
 datamodel-code-generator = "^0.22.1"

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -273,7 +273,7 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes,too-many-publ
     def get_detector(
         self,
         id: Union[str, Detector],
-        request_timeout: Optional[float] = None,
+        request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
     ) -> Detector:  # pylint: disable=redefined-builtin
         """
         Get a Detector by id.
@@ -675,7 +675,7 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes,too-many-publ
         inspection_id: Optional[str] = None,
         metadata: Union[dict, str, None] = None,
         image_query_id: Optional[str] = None,
-        request_timeout: Optional[float] = None,
+        request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
     ) -> ImageQuery:
         """
         Evaluates an image with Groundlight. This is the core method for getting predictions about images.

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -270,7 +270,11 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes,too-many-publ
         obj = self.user_api.who_am_i()
         return obj["is_superuser"]
 
-    def get_detector(self, id: Union[str, Detector]) -> Detector:  # pylint: disable=redefined-builtin
+    def get_detector(
+        self,
+        id: Union[str, Detector],
+        request_timeout: Optional[float] = None,
+    ) -> Detector:  # pylint: disable=redefined-builtin
         """
         Get a Detector by id.
 
@@ -281,6 +285,8 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes,too-many-publ
             print(detector)
 
         :param id: the detector id
+        :param request_timeout: The request timeout for the image query submission API request. Most users will not need
+            to modify this. If not set, the default value will be used.
 
         :return: Detector
         """
@@ -289,7 +295,8 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes,too-many-publ
             # Short-circuit
             return id
         try:
-            obj = self.detectors_api.get_detector(id=id, _request_timeout=DEFAULT_REQUEST_TIMEOUT)
+            request_timeout = request_timeout if request_timeout is not None else DEFAULT_REQUEST_TIMEOUT
+            obj = self.detectors_api.get_detector(id=id, _request_timeout=request_timeout)
         except NotFoundException as e:
             raise NotFoundError(f"Detector with id '{id}' not found") from e
         return Detector.parse_obj(obj.to_dict())
@@ -750,8 +757,8 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes,too-many-publ
         :param image_query_id: The ID for the image query. This is to enable specific functionality
                             and is not intended for general external use. If not set, a random ID
                             will be generated.
-        :param request_timeout: The total request timeout for the image query submission API request. Most users will
-            not need to modify this. If not set, the default value will be used.
+        :param request_timeout: The request timeout for the image query submission API request. Most users will not need
+            to modify this. If not set, the default value will be used.
 
         :return: ImageQuery with query details and result (if wait > 0)
         :raises ValueError: If wait > 0 when want_async=True

--- a/src/groundlight/client.py
+++ b/src/groundlight/client.py
@@ -272,9 +272,9 @@ class Groundlight:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
     def get_detector(
         self,
-        id: Union[str, Detector],
+        id: Union[str, Detector],  # pylint: disable=redefined-builtin
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
-    ) -> Detector:  # pylint: disable=redefined-builtin
+    ) -> Detector:
         """
         Get a Detector by id.
 

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -241,7 +241,7 @@ def test_get_detector(gl: Groundlight, detector: Detector):
 def test_get_detector_with_low_request_timeout(gl: Groundlight, detector: Detector):
     """
     Verifies that get_detector respects the request_timeout parameter and raises a MaxRetryError when timeout is
-    exceeded. Verifies that request_timeout parameter can be a float or a tuple.
+    low. Verifies that request_timeout parameter can be a float or a tuple.
     """
     with pytest.raises(MaxRetryError):
         # Setting a very low request_timeout value should result in a timeout.
@@ -383,8 +383,8 @@ def test_submit_image_query_with_human_review_param(gl: Groundlight, detector: D
 
 def test_submit_image_query_with_low_request_timeout(gl: Groundlight, detector: Detector, image: str):
     """
-    Verifies that submit_image_query respects the request_timeout parameter and raises a ReadTimeoutError when timeout
-    is exceeded. Verifies that request_timeout parameter can be a float or a tuple.
+    Verifies that submit_image_query respects the request_timeout parameter and raises a ConnectTimeoutError or
+    ReadTimeoutError when timeout is low. Verifies that request_timeout parameter can be a float or a tuple.
     """
     with pytest.raises((ConnectTimeoutError, ReadTimeoutError)):
         # Setting a very low request_timeout value should result in a timeout.

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -27,7 +27,7 @@ from model import (
     PaginatedDetectorList,
     PaginatedImageQueryList,
 )
-from urllib3.exceptions import MaxRetryError, ReadTimeoutError
+from urllib3.exceptions import ConnectTimeoutError, MaxRetryError, ReadTimeoutError
 from urllib3.util.retry import Retry
 
 DEFAULT_CONFIDENCE_THRESHOLD = 0.9
@@ -386,14 +386,14 @@ def test_submit_image_query_with_low_request_timeout(gl: Groundlight, detector: 
     Verifies that submit_image_query respects the request_timeout parameter and raises a ReadTimeoutError when timeout
     is exceeded. Verifies that request_timeout parameter can be a float or a tuple.
     """
-    with pytest.raises(ReadTimeoutError):
+    with pytest.raises((ConnectTimeoutError, ReadTimeoutError)):
         # Setting a very low request_timeout value should result in a timeout.
         # NOTE: request_timeout=0 seems to have special behavior that does not result in a timeout.
         gl.submit_image_query(detector=detector, image=image, human_review="NEVER", request_timeout=1e-8)
 
-    with pytest.raises(ReadTimeoutError):
+    with pytest.raises((ConnectTimeoutError, ReadTimeoutError)):
         # Ensure a tuple can be passed.
-        gl.submit_image_query(detector=detector, image=image, human_review="NEVER", request_timeout=(1e-8, 1e-8))
+        gl.submit_image_query(detector=detector, image=image, human_review="NEVER", request_timeout=(5, 1e-8))
 
 
 @pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing detector metadata.")

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -222,6 +222,21 @@ def test_get_detector(gl: Groundlight, detector: Detector):
     assert isinstance(_detector, Detector)
 
 
+def test_get_detector_with_low_request_timeout(gl: Groundlight, detector: Detector):
+    """
+    Verifies that get_detector respects the request_timeout parameter and raises a ReadTimeoutError when timeout is
+    exceeded. Verifies that request_timeout parameter can be a float or a tuple.
+    """
+    with pytest.raises(ReadTimeoutError):
+        # Setting a very low request_timeout value should result in a timeout.
+        # NOTE: request_timeout=0 seems to have special behavior that does not result in a timeout.
+        gl.get_detector(id=detector.id, request_timeout=1e-8)
+
+    with pytest.raises(ReadTimeoutError):
+        # Ensure a tuple can be passed.
+        gl.get_detector(id=detector.id, request_timeout=(1e-8, 1e-8))
+
+
 def test_get_detector_by_name(gl: Groundlight, detector: Detector):
     _detector = gl.get_detector_by_name(name=detector.name)
     assert str(_detector)
@@ -352,13 +367,17 @@ def test_submit_image_query_with_human_review_param(gl: Groundlight, detector: D
 
 def test_submit_image_query_with_low_request_timeout(gl: Groundlight, detector: Detector, image: str):
     """
-    Test that submit_image_query respects the request_timeout parameter and raises a ReadTimeoutError when timeout is
-    exceeded.
+    Verifies that submit_image_query respects the request_timeout parameter and raises a ReadTimeoutError when timeout is
+    exceeded. Verifies that request_timeout parameter can be a float or a tuple.
     """
     with pytest.raises(ReadTimeoutError):
         # Setting a very low request_timeout value should result in a timeout.
         # NOTE: request_timeout=0 seems to have special behavior that does not result in a timeout.
         gl.submit_image_query(detector=detector, image=image, human_review="NEVER", request_timeout=1e-8)
+
+    with pytest.raises(ReadTimeoutError):
+        # Ensure a tuple can be passed.
+        gl.submit_image_query(detector=detector, image=image, human_review="NEVER", request_timeout=(1e-8, 1e-8))
 
 
 @pytest.mark.skip_for_edge_endpoint(reason="The edge-endpoint does not support passing detector metadata.")

--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -240,7 +240,7 @@ def test_get_detector(gl: Groundlight, detector: Detector):
 
 def test_get_detector_with_low_request_timeout(gl: Groundlight, detector: Detector):
     """
-    Verifies that get_detector respects the request_timeout parameter and raises a ReadTimeoutError when timeout is
+    Verifies that get_detector respects the request_timeout parameter and raises a MaxRetryError when timeout is
     exceeded. Verifies that request_timeout parameter can be a float or a tuple.
     """
     with pytest.raises(MaxRetryError):
@@ -383,8 +383,8 @@ def test_submit_image_query_with_human_review_param(gl: Groundlight, detector: D
 
 def test_submit_image_query_with_low_request_timeout(gl: Groundlight, detector: Detector, image: str):
     """
-    Verifies that submit_image_query respects the request_timeout parameter and raises a ReadTimeoutError when timeout is
-    exceeded. Verifies that request_timeout parameter can be a float or a tuple.
+    Verifies that submit_image_query respects the request_timeout parameter and raises a ReadTimeoutError when timeout
+    is exceeded. Verifies that request_timeout parameter can be a float or a tuple.
     """
     with pytest.raises(ReadTimeoutError):
         # Setting a very low request_timeout value should result in a timeout.


### PR DESCRIPTION
This PR includes two distinct changes.
- Adds a new parameter `http_transport_retries` to the `Groundlight` constructor, enabling the retry behavior to be modified when initializing a `Groundlight` instance. 
  - The retry behavior specified will apply to all API requests made through the `Groundlight` instance. 
  - Currently no way is provided to configure the retry behavior per-request, or to change it once the `Groundlight` instance has been initialized (this is technically possible but awkward). 
  - I added a test to verify that we can pass the parameter in and it gets passed through to the inner API client.
- Adds a `request_timeout` parameter to the `get_detector` method which enables changing the request timeout values for the request. 
  - An identical parameter was previously added for `submit_image_query`. Eventually I think we'll want to make this available for all methods, but for now we don't need that.
  - I added a test to verify that this parameter works properly.

These changes are intended to be utilized by the edge endpoint to improve behavior under poor network connectivity. 