### PR TITLE
Fix false 'headers not set' warning on DELETE endpoints

### DIFF
--- a/src/groundlight/internalapi.py
+++ b/src/groundlight/internalapi.py
@@ -176,7 +176,7 @@ class GroundlightApiClient(ApiClient):
         # Note we don't look for header_param in kwargs here, because this method is only called in one place
         # in the generated code, so we can afford to make this brittle.
         header_param = args[4]  # that's the number in the list
-        if not header_param:
+        if header_param is None:
             # This will never happen in normal usage.
             logger.warning("Can't set request-id because headers not set")
         elif not header_param.get(self.REQUEST_ID_HEADER, None):


### PR DESCRIPTION
## Summary
- The check `if not header_param:` in `GroundlightApiClient.call_api` incorrectly treats an empty dict `{}` as falsy, skipping `X-Request-Id` injection and logging a spurious warning for every DELETE endpoint (`delete_detector`, `delete_priming_group`, `delete_rule`, `reset_detector`) and `edge_report_metrics_create`
- These endpoints have empty `accept` and `content_type` in their OpenAPI-generated `headers_map`, so no Accept/Content-Type headers are added, leaving `params["header"]` as `{}`
- Fix: change `if not header_param:` to `if header_param is None:` so an empty dict falls through to the `elif` branch and gets the `X-Request-Id` header set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Brandon: Without having to understand the entire generated code path, we can reason that this code change is an improvement. If headers is an empty dict, we still want to inject the request id. 
This code is ancient, there's plenty we could improve here but this PR will stick to the minimal change to fix the bug that proper usage can create a warning without much to do about it and cause the request id to not be set