### PR TITLE
fix(test): drop pipeline_config from invalid-priming-group test

### DIFF
--- a/test/integration/test_groundlight.py
+++ b/test/integration/test_groundlight.py
@@ -985,14 +985,12 @@ def test_create_detector_with_invalid_priming_group_id(gl: Groundlight, detector
     """
     name = detector_name("Test invalid priming")
     query = "Is there a dog?"
-    pipeline_config = "never-review"
     priming_group_id = "prgrp_nonexistent12345678901234567890"
 
     with pytest.raises(NotFoundException) as exc_info:
         gl.create_detector(
             name=name,
             query=query,
-            pipeline_config=pipeline_config,
             priming_group_id=priming_group_id,
         )
 


### PR DESCRIPTION
## Summary

- The backend now rejects `pipeline_config` + `priming_group_id` together as mutually exclusive
- `test_create_detector_with_invalid_priming_group_id` was passing both, so it now fails with a 400 ("mutually exclusive") instead of reaching the PG-lookup step that returns the 404 the test asserts on.
- Drops `pipeline_config` from the call. The test still does what its docstring says: passing a fake priming_group_id and expecting a 404 mentioning `PrimingGroup`.